### PR TITLE
Mappanel: undefined state bugfix

### DIFF
--- a/src/GeoExt/panel/Map.js
+++ b/src/GeoExt/panel/Map.js
@@ -323,7 +323,7 @@ Ext.define('GeoExt.panel.Map', {
     getState: function() {
         var me = this,
             map = me.getMap(),
-            state = me.callParent(arguments) || {},
+            state = me.callParent(arguments),
             layer;
 
         // Ext delays the call to getState when a state event
@@ -340,20 +340,20 @@ Ext.define('GeoExt.panel.Map', {
         // dimensions or no layers
         
         if (center)  {
-            state.x = center.lon;
-            state.y = center.lat;
-            state.zoom = map.getZoom();
+            state = me.addPropertyToState(state, 'x', center.lon);
+            state = me.addPropertyToState(state, 'y', center.lat);
+            state = me.addPropertyToState(state, 'zoom', map.getZoom());
         }
         
         me.layers.each(function(modelInstance) {
-           layer = modelInstance.getLayer();
-           layerId = this.prettyStateKeys 
+            layer = modelInstance.getLayer();
+            layerId = this.prettyStateKeys 
                    ? modelInstance.get('name') 
                    : modelInstance.get('id');
-           state["visibility_" + layerId] = layer.getVisibility();
-           state["opacity_" + layerId] = (layer.opacity === null) 
-                                       ? 1 
-                                       : layer.opacity;
+            state = me.addPropertyToState(state, "visibility_" + layerId, 
+                layer.getVisibility());
+            state = me.addPropertyToState(state, "opacity_" + layerId, 
+                (layer.opacity === null) ? 1 : layer.opacity);
         }, me);
         
         return state;  


### PR DESCRIPTION
The mappanel now uses AbstractComponent's addPropertyToState to update the state object.
This fixes the "state is undefined" error on state.x = ...
