### PR TITLE
fix GeoExt.panel.Map - get layer name from 'title' field

### DIFF
--- a/src/GeoExt/panel/Map.js
+++ b/src/GeoExt/panel/Map.js
@@ -349,7 +349,7 @@ Ext.define('GeoExt.panel.Map', {
         me.layers.each(function(modelInstance) {
             layer = modelInstance.getLayer();
             layerId = this.prettyStateKeys 
-                   ? modelInstance.get('name') 
+                   ? modelInstance.get('title') 
                    : modelInstance.get('id');
             state = me.addPropertyToState(state, "visibility_" + layerId, 
                 layer.getVisibility());


### PR DESCRIPTION
The correct field to get layer name is 'title', not 'name'.
