### PR TITLE
fix - GeoExt.panel.Map getState no longer uses addPropertyToState

### DIFF
--- a/src/GeoExt/panel/Map.js
+++ b/src/GeoExt/panel/Map.js
@@ -324,7 +324,7 @@ Ext.define('GeoExt.panel.Map', {
     getState: function() {
         var me = this,
             map = me.getMap(),
-            state = me.callParent(arguments),
+            state = me.callParent(arguments) || {},
             layer;
 
         // Ext delays the call to getState when a state event
@@ -339,12 +339,11 @@ Ext.define('GeoExt.panel.Map', {
         var center = map.getCenter();
         // map may not be centered yet, because it may still have zero
         // dimensions or no layers
-        
-        if (center)  {
-            state = me.addPropertyToState(state, 'x', center.lon);
-            state = me.addPropertyToState(state, 'y', center.lat);
-            state = me.addPropertyToState(state, 'zoom', map.getZoom());
-        }
+        center && Ext.applyIf(state, {
+            "x": center.lon,
+            "y": center.lat,
+            "zoom": map.getZoom()
+        });
         
         me.layers.each(function(modelInstance) {
             layer = modelInstance.getLayer();


### PR DESCRIPTION
GeoExt.panel.Map -> the initialisation of 'zoom', 'center' & 'extent' are now outside of the 'config' property (de0b64befaf9067774a84f100b3d9348c1b63fb6).  The tests now fails because of the use of the addPropertyToState method (3c5e15ef7133847c578b9ac9c13115e6eb6a26fd).

Basically, in GeoExt 1.x, the getState method returned a static hash of map panel and map properties.  Since the addPropertyToState checks if a property as the same value in its initialConfig property, setting it to the same default value again fails and the property is not set.

This patch fixes the issue.
