### PR TITLE
minor changes to the mappanel example

### DIFF
--- a/examples/mappanel/mappanel.js
+++ b/examples/mappanel/mappanel.js
@@ -21,12 +21,12 @@ Ext.application({
         map.addLayers([wms]);
         
         mappanel = Ext.create('GeoExt.panel.Map', {
-            title: 'The GeoExt.panel.Map-class'
-            ,map: map
-            ,center: '12.3046875,51.48193359375'
-            ,zoom: 6
-//            ,extent: '12.87,52.35,13.96,52.66' 
-            ,dockedItems: [{
+            title: 'The GeoExt.panel.Map-class',
+            map: map,
+            center: '12.3046875,51.48193359375',
+            zoom: 6,
+//            extent: '12.87,52.35,13.96,52.66',
+            dockedItems: [{
                 xtype: 'toolbar',
                 dock: 'top',
                 items: [{


### PR DESCRIPTION
Two changes:
- do not use "heading commas" when defining object properties
- rely on loader.js
