### PR TITLE
fix all tests - now loading ext-all-debug - IE

### DIFF
--- a/tests/LegendImage.html
+++ b/tests/LegendImage.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css">
+    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css" />
     <script type="text/javascript" charset="utf-8" src="http://cdn.sencha.io/ext-4.1.0-gpl/ext-all-debug.js" ></script>
 
     <script src="http://openlayers.org/api/2.12-rc3/OpenLayers.js"></script>
@@ -11,7 +11,6 @@
             disableCaching: false,
             enabled: true,
             paths: {
-                Ext: 'http://cdn.sencha.io/ext-4.1.0-gpl/src',
                 GeoExt: '../src/GeoExt'
             }
         });
@@ -85,6 +84,7 @@
 
 
     </script>
+  </head>
   <body>
     <div id="legend"></div>
   </body>

--- a/tests/container/LayerLegend.html
+++ b/tests/container/LayerLegend.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html debug="true">
   <head>
-    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css">
-    <script type="text/javascript" charset="utf-8" src="http://cdn.sencha.io/ext-4.1.0-gpl/ext-debug.js" ></script>
+    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css" />
+    <script type="text/javascript" charset="utf-8" src="http://cdn.sencha.io/ext-4.1.0-gpl/ext-all-debug.js" ></script>
 
     <script src="http://openlayers.org/api/2.12-rc3/OpenLayers.js"></script>
 
@@ -11,7 +11,6 @@
             disableCaching: false,
             enabled: true,
             paths: {
-                Ext: 'http://cdn.sencha.io/ext-4.1.0-gpl/src',
                 GeoExt: '../../src/GeoExt'
             }
         });
@@ -146,6 +145,7 @@
         }
 
     </script>
+  </head>
   <body>
     <div id="legend"></div>
   </body>

--- a/tests/container/URLLegend.html
+++ b/tests/container/URLLegend.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html debug="true">
   <head>
-    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css">
-    <script type="text/javascript" charset="utf-8" src="http://cdn.sencha.io/ext-4.1.0-gpl/ext-debug.js" ></script>
+    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css" />
+    <script type="text/javascript" charset="utf-8" src="http://cdn.sencha.io/ext-4.1.0-gpl/ext-all-debug.js" ></script>
 
     <script src="http://openlayers.org/api/2.12-rc3/OpenLayers.js"></script>
 
@@ -11,7 +11,6 @@
             disableCaching: false,
             enabled: true,
             paths: {
-                Ext: 'http://cdn.sencha.io/ext-4.1.0-gpl/src',
                 GeoExt: '../../src/GeoExt'
             }
         });
@@ -85,6 +84,7 @@
         }
 
     </script>
+  </head>
   <body>
     <div id="legend"></div>
   </body>

--- a/tests/container/VectorLegend.html
+++ b/tests/container/VectorLegend.html
@@ -1,6 +1,6 @@
 <html><head>
-<link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css">
-<script type="text/javascript" charset="utf-8" src="http://cdn.sencha.io/ext-4.1.0-gpl/ext-debug.js" ></script>
+<link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css" />
+<script type="text/javascript" charset="utf-8" src="http://cdn.sencha.io/ext-4.1.0-gpl/ext-all-debug.js" ></script>
 
 <script src="http://openlayers.org/api/2.12-rc3/OpenLayers.js"></script>
 
@@ -9,7 +9,6 @@
         disableCaching: false,
         enabled: true,
         paths: {
-            Ext: 'http://cdn.sencha.io/ext-4.1.0-gpl/src',
             GeoExt: '../../src/GeoExt'
         }
     });

--- a/tests/container/WMSLegend.html
+++ b/tests/container/WMSLegend.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html debug="true">
   <head>
-    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css">
-    <script type="text/javascript" charset="utf-8" src="http://cdn.sencha.io/ext-4.1.0-gpl/ext-debug.js" ></script>
+    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css" />
+    <script type="text/javascript" charset="utf-8" src="http://cdn.sencha.io/ext-4.1.0-gpl/ext-all-debug.js" ></script>
 
     <script src="http://openlayers.org/api/2.12-rc3/OpenLayers.js"></script>
 
@@ -11,7 +11,6 @@
             disableCaching: false,
             enabled: true,
             paths: {
-                Ext: 'http://cdn.sencha.io/ext-4.1.0-gpl/src',
                 GeoExt: '../../src/GeoExt'
             }
         });
@@ -306,6 +305,7 @@
 
 
     </script>
+  </head>
   <body>
     <div id="legendwms"></div>
     <div id="mappanel"></div>

--- a/tests/panel/Legend.html
+++ b/tests/panel/Legend.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html debug="true">
   <head>
-    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css">
-    <script type="text/javascript" charset="utf-8" src="http://cdn.sencha.io/ext-4.1.0-gpl/ext-debug.js" ></script>
+    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css" />
+    <script type="text/javascript" charset="utf-8" src="http://cdn.sencha.io/ext-4.1.0-gpl/ext-all-debug.js" ></script>
 
     <script src="http://openlayers.org/api/2.12-rc3/OpenLayers.js"></script>
 
@@ -11,7 +11,6 @@
             disableCaching: false,
             enabled: true,
             paths: {
-                Ext: 'http://cdn.sencha.io/ext-4.1.0-gpl/src',
                 GeoExt: '../../src/GeoExt'
             }
         });
@@ -332,6 +331,7 @@
         }
 
     </script>
+  </head>
   <body>
     <div id="legendpanel"></div>
     <div id="mappanel"></div>

--- a/tests/panel/Map.html
+++ b/tests/panel/Map.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html debug="true">
   <head>
-    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css">
-    <script type="text/javascript" charset="utf-8" src="http://cdn.sencha.io/ext-4.1.0-gpl/ext-debug.js" ></script>
+    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css" />
+    <script type="text/javascript" charset="utf-8" src="http://cdn.sencha.io/ext-4.1.0-gpl/ext-all-debug.js" ></script>
 
     <script src="http://openlayers.org/api/2.12-rc3/OpenLayers.js"></script>
 
@@ -11,13 +11,12 @@
             disableCaching: false,
             enabled: true,
             paths: {
-                Ext: 'http://cdn.sencha.io/ext-4.1.0-gpl/src',
                 GeoExt: '../../src/GeoExt'
             }
         });
 
-        Ext.require(['Ext.layout.container.Border', 'GeoExt.panel.Map', 'GeoExt.slider.Zoom']);
-    
+        Ext.require(['GeoExt.panel.Map', 'GeoExt.slider.Zoom']);
+ 
         // the hidden span element that contains the test iframe
         var hiddenSpan = window.parent.Test.AnotherWay._g_test_iframe.frameElement.parentNode;
        

--- a/tests/state/PermalinkProvider.html
+++ b/tests/state/PermalinkProvider.html
@@ -1,16 +1,22 @@
 <!DOCTYPE html>
 <html debug="true">
   <head>
-    <link rel="stylesheet" type="text/css" href="../../../../ext-4.0.2a/resources/css/ext-all.css">
-    <script type="text/javascript" src="http://openlayers.org/api/2.11/OpenLayers.js"></script>
-    <script type="text/javascript" src="../../../../ext-4.0.2a/ext-all.js"></script>
-    <script type="text/javascript" src="../../../src/GeoExt.js"></script>
-    <script type="text/javascript" src="../../../src/data/models/Layer.js"></script>
-    <script type="text/javascript" src="../../../src/data/store/Layer.js"></script>
-    <script type="text/javascript" src="../../../src/panel/Map.js"></script>
-    <script type="text/javascript" src="../../../src/state/PermalinkProvider.js"></script>    
+    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css" />
+    <script type="text/javascript" charset="utf-8" src="http://cdn.sencha.io/ext-4.1.0-gpl/ext-all-debug.js" ></script>
+
+    <script src="http://openlayers.org/api/2.12-rc3/OpenLayers.js"></script>
 
     <script type="text/javascript">
+    Ext.Loader.setConfig({
+        disableCaching: false,
+        enabled: true,
+        paths: {
+            GeoExt: '../../src/GeoExt'
+        }
+    });
+
+    Ext.require(['GeoExt.panel.Map', 'GeoExt.state.PermalinkProvider']);
+
     function test_set(t) {
         t.plan(1);
 
@@ -237,6 +243,7 @@
              "getLink returns expected string [1]");
     }
     </script>
+  </head>
   <body>
   </body>
 </html>


### PR DESCRIPTION
This makes all tests now pointing to ext-all-debug.js.  The loader is no longer used to fetch Ext files in tests.
