### PR TITLE
fix GeoExt.window.Popup - cls and events

### DIFF
--- a/src/GeoExt/window/Popup.js
+++ b/src/GeoExt/window/Popup.js
@@ -111,7 +111,8 @@ Ext.define('GeoExt.window.Popup', {
     location: null,
     
     /** 
-     * @cfg {String} popupCls
+     * @property {String} popupCls
+     * @private
      * CSS class name for the popup DOM elements.
      */
     popupCls: "gx-popup",
@@ -163,7 +164,6 @@ Ext.define('GeoExt.window.Popup', {
             this.addAnchorEvents();
         }
 
-        this.baseCls = this.popupCls + " " + this.baseCls;
         this.elements += ',anc';
         
         this.callParent(arguments);
@@ -180,6 +180,7 @@ Ext.define('GeoExt.window.Popup', {
      */
     onRender: function(ct, position) {
         this.callParent(arguments);
+        this.addClass(this.popupCls);
         this.ancCls = this.popupCls + "-anc";
         
         //create anchor dom element.
@@ -408,8 +409,6 @@ Ext.define('GeoExt.window.Popup', {
         
         this.on({
             "resize": this.position,
-            "collapse": this.position,
-            "expand": this.position,
             scope: this
         });
     },
@@ -425,8 +424,6 @@ Ext.define('GeoExt.window.Popup', {
         });
 
         this.un("resize", this.position, this);
-        this.un("collapse", this.position, this);
-        this.un("expand", this.position, this);
     },
 
     /**


### PR DESCRIPTION
This contains 2 fixes :
- the popupCls added using native Ext method instead of appending it with baseCls.  Collapsing wasn't working
- when collapsing/expanding while having the anchor active, the "move" event was fired twice, once by "resize" and one more time by "collapse/expand".  That means we only need to listen to "resize".
