### PR TITLE
fix LayerStore tests, pass in IE8 IE9 FF Chr Saf, not Op

### DIFF
--- a/tests/data/LayerStore.html
+++ b/tests/data/LayerStore.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html debug="true">
   <head>
-    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css">
+    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css" />
     <script type="text/javascript" src="http://openlayers.org/api/2.12-rc3/OpenLayers.js"></script>
     <script type="text/javascript" src="http://cdn.sencha.io/ext-4.1.0-gpl/ext-all-debug.js"></script>
 
@@ -14,16 +14,13 @@
                 "GeoExt": "../../src/GeoExt"
             }
         });
-     
-        function createMap() {
-            var map = new OpenLayers.Map();
-            return map;
+
+        function createSingleMap() {
+            return new OpenLayers.Map("map");
         }
 
         function loadMapPanel() {
-            var map = createMap();
-
-            var mapPanel = Ext.create('GeoExt.panel.Map', {
+            return Ext.create('GeoExt.panel.Map', {
                 // panel options
                 id: "map-panel",
                 title: "GeoExt MapPanel",
@@ -31,12 +28,10 @@
                 height: 400,
                 width: 600,
                 // map panel-specific options
-                map: map,
+                map: new OpenLayers.Map(),
                 center: new OpenLayers.LonLat(5, 45),
                 zoom: 4
             });
-
-            return mapPanel;
         }
 
         function test_constructor(t) {
@@ -79,7 +74,7 @@
             t.eq(map.layers.length,0,"removeLayer on MapPanel's LayerStore removes layer from map");
             t.eq(mapPanel.layers.getCount(),0,"removeLayer on MapPanel's LayerStore removes layer from map");
 
-            mapPanel.layers.add(mapPanel.layers.proxy.reader.read(layer).records);
+            mapPanel.layers.addLayers([layer]);
             t.eq(map.layers.length,1,"Adding layer to MapPanel's LayerStore adds only one layer to map");
             t.eq(mapPanel.layers.getCount(),1,"Adding layers to MapPanel's LayerStore does not create duplicate layers");
 
@@ -120,7 +115,7 @@
         function test_load_clear(t) {
             t.plan(2);
             
-            var map = new OpenLayers.Map("mappanel");
+            var map = createSingleMap();
             var store = Ext.create('GeoExt.data.LayerStore', {
                 map: map
             });
@@ -141,10 +136,18 @@
         function test_bind_unbind(t) {
             t.plan(29);
             
-            var map = new OpenLayers.Map("mappanel");
+            var map = createSingleMap();
             var store = Ext.create('GeoExt.data.LayerStore');
             var layers = [new OpenLayers.Layer.Vector("Foo layer"),
                           new OpenLayers.Layer.Vector("Bar layer")];
+            var records = [
+                GeoExt.data.LayerModel.createFromLayer(
+                   new OpenLayers.Layer.Vector("Foo layer")
+                ),
+                GeoExt.data.LayerModel.createFromLayer(
+                   new OpenLayers.Layer.Vector("Bar layer")
+                )
+            ];
 
             var reinit_test_data = function () {
                 // unbind store
@@ -159,7 +162,7 @@
                 t.eq(store.getCount(), 0, "there is no more records in the store");
 
                 // add testing data to store and map
-                store.add(layers);
+                store.add(records);
                 map.addLayers(layers);
                 t.eq(map.layers.length, 2, "initial layers are loaded in the map");
                 t.eq(store.getCount(), 2, "initial records are loaded in the store");
@@ -183,7 +186,7 @@
             store.bind(map, {initDir: GeoExt.data.LayerStore.MAP_TO_STORE});
             t.eq(map.layers.length, 2, "initial records are not synchronized to map");
             t.eq(store.getCount(), 4, "initial layers are synchronized to store");
-            store.remove(records[0]);
+            store.remove(store.getAt(0));
             t.eq(store.getCount(), 3, "removing record not present in map has been well removed");
             t.eq(map.layers.length, 2, "nothing to remove in map when removing record not present in map");
 
@@ -205,16 +208,15 @@
             
             t.plan(6);
             
-            var map = new OpenLayers.Map("mappanel");
+            var map = createSingleMap();
+            var layer = new OpenLayers.Layer.Vector();
             var store = Ext.create('GeoExt.data.LayerStore', {
                 map: map
             });
-            var record = new GeoExt.data.LayerRecord({
-                layer: new OpenLayers.Layer.Vector()
-            });
 
-            store.add([record]);
+            store.addLayers([layer]);
             t.eq(store.getCount(), 1, "adding a single record to the store adds one record");
+            var record = store.getAt(0);
             
             store.remove(record);
             t.eq(store.getCount(), 0, "removing a single record from the store removes one record");
@@ -225,8 +227,7 @@
             t.eq(map.layers.length, 1, "map has a single layer before adding copy");
             
             // create a copy of the record with the same layer
-            var copy = record.copy(); // record with same id will replace original
-            copy.setLayer(record.getLayer()); // force records to have same layer            
+            var copy = GeoExt.data.LayerModel.createFromLayer(layer)
             store.add(copy);
             t.eq(store.getCount(), 1, "store has a single record after adding copy");
             t.eq(map.layers.length, 1, "map has a single layer after adding copy");
@@ -237,7 +238,7 @@
             
             t.plan(24);
             
-            var map = new OpenLayers.Map("mappanel");
+            var map = createSingleMap();
             var a = new OpenLayers.Layer.Vector("a");
             var b = new OpenLayers.Layer.Vector("b");
             var c = new OpenLayers.Layer.Vector("c");
@@ -246,7 +247,7 @@
                 map: map
             });
             
-            store.add(store.reader.readRecords([a, b, c]).records);
+            store.addLayers([a, b, c]);
 
             t.eq(store.getCount(), 3, "[a, b, c] three layers in store");
             t.eq(store.getAt(0).getLayer().name, "a", "[a, b, c] first layer correct in store");
@@ -289,7 +290,7 @@
             
             t.plan(10);
             
-            var map = new OpenLayers.Map("mappanel");
+            var map = createSingleMap();
             var a = new OpenLayers.Layer.Vector("a");
             var b = new OpenLayers.Layer.Vector("b");
             var c = new OpenLayers.Layer.Vector("c");
@@ -299,10 +300,10 @@
                 map: map
             });
             
-            store.add(store.reader.readRecords([a, b, c]).records);
+            store.addLayers([a, b, c]);
             
             // insert d into second position
-            store.insert(1, store.reader.readRecords([d]).records);
+            store.insert(1, GeoExt.data.LayerModel.createFromLayer(d));
             
             t.eq(store.getCount(), 4, "[a, d, b, c] four layers in store");
             t.eq(store.getAt(0).getLayer().name, "a", "[a, d, b, c] first layer correct in store");
@@ -322,7 +323,7 @@
         function test_update(t) {
             t.plan(2);
             
-            var map = new OpenLayers.Map("mappanel");
+            var map = createSingleMap();
             var layer = new OpenLayers.Layer("foo");
             map.addLayer(layer);
 
@@ -469,6 +470,7 @@
     </script>
   </head>
   <body>
+    <div id="map" style="width:100px;height:100px;"></div>
     <div id="mappanel"></div>
     <div id="mappanel2"></div>
   </body>


### PR DESCRIPTION
So, now all LayerStore tests pass in InternetExplorer 8-9, FireFox, Chrome and Safari.  Opera test doesn't complete without telling anything, so it'll require more investigation.
