### PR TITLE
test - legend - IE fixes

### DIFF
--- a/tests/container/UrlLegend.html
+++ b/tests/container/UrlLegend.html
@@ -28,7 +28,7 @@
                     new OpenLayers.Layer("foo")
                 ]
             });
-            var legend = Ext.create("GeoExt.UrlLegend", {
+            var legend = Ext.create("GeoExt.container.UrlLegend", {
                 layerRecord: store.getAt(0),
                 renderTo: "legend"
             });
@@ -79,8 +79,8 @@
                 ]
             });
 
-            t.ok(GeoExt.UrlLegend.supports(store.getAt(0)) > 0, "layer record with a legendURL property is supported.");
-            t.eq(GeoExt.UrlLegend.supports(store.getAt(1)), 0, "layer record without a legendURL property is not supported.");
+            t.ok(GeoExt.container.UrlLegend.supports(store.getAt(0)) > 0, "layer record with a legendURL property is supported.");
+            t.eq(GeoExt.container.UrlLegend.supports(store.getAt(1)), 0, "layer record without a legendURL property is not supported.");
         }
 
     </script>

--- a/tests/container/VectorLegend.html
+++ b/tests/container/VectorLegend.html
@@ -24,13 +24,13 @@
         var legend;
 
         // no config (won't render)
-        legend = Ext.create("GeoExt.VectorLegend");
-        t.ok(legend instanceof GeoExt.VectorLegend, "instance of VectorLegend");
-        t.ok(legend instanceof GeoExt.LayerLegend, "instance of LayerLegend");
+        legend = Ext.create("GeoExt.container.VectorLegend");
+        t.ok(legend instanceof GeoExt.container.VectorLegend, "instance of VectorLegend");
+        t.ok(legend instanceof GeoExt.container.LayerLegend, "instance of LayerLegend");
         legend.destroy();
         
         // rules & symbolType
-        legend = Ext.create("GeoExt.VectorLegend", {
+        legend = Ext.create("GeoExt.container.VectorLegend", {
             legendTitle: "my title",
             renderTo: "legendpanel",
             rules: [
@@ -65,7 +65,7 @@
     function test_setCurrentScaleDenominator(t) {
         t.plan(12);
         
-        var legend = Ext.create("GeoExt.VectorLegend", {
+        var legend = Ext.create("GeoExt.container.VectorLegend", {
             legendTitle: "my title",
             renderTo: "legendpanel",
             rules: [
@@ -112,7 +112,7 @@
 
         var store = Ext.create("GeoExt.data.LayerStore", {map: map});
 
-        var legend = Ext.create("GeoExt.VectorLegend", {
+        var legend = Ext.create("GeoExt.container.VectorLegend", {
             layerRecord: store.getAt(0),
             renderTo: "legendpanel",
             symbolType: "Point"
@@ -141,7 +141,7 @@
         map.zoomToMaxExtent();
 
         var store = Ext.create("GeoExt.data.LayerStore", {map: map});
-        var legend = Ext.create("GeoExt.VectorLegend", {
+        var legend = Ext.create("GeoExt.container.VectorLegend", {
             layerRecord: store.getAt(1),
             renderTo: "legendpanel",
             symbolType: "Point"
@@ -177,7 +177,7 @@
 
         var store = Ext.create("GeoExt.data.LayerStore", {map: map});
         
-        var legend = Ext.create("GeoExt.VectorLegend", {
+        var legend = Ext.create("GeoExt.container.VectorLegend", {
             layerRecord: store.getAt(0),
             renderTo: "legendpanel",
             symbolType: "Point"
@@ -242,7 +242,7 @@
         ];
         
         // [a] test legend with default config
-        legend = Ext.create("GeoExt.VectorLegend", {
+        legend = Ext.create("GeoExt.container.VectorLegend", {
             renderTo: "legendpanel",
             rules: rules
         });
@@ -252,7 +252,7 @@
         legend.destroy();
         
         // [b] test legend with custom untitledPrefix
-        legend = Ext.create("GeoExt.VectorLegend", {
+        legend = Ext.create("GeoExt.container.VectorLegend", {
             renderTo: "legendpanel",
             rules: rules,
             untitledPrefix: "foo "
@@ -263,7 +263,7 @@
         legend.destroy();
         
         // [c] test legend with null untitledPrefix
-        legend = Ext.create("GeoExt.VectorLegend", {
+        legend = Ext.create("GeoExt.container.VectorLegend", {
             renderTo: "legendpanel",
             rules: rules,
             untitledPrefix: null
@@ -299,7 +299,7 @@
             new OpenLayers.Feature.Vector(new OpenLayers.Geometry.Point(1,1))
         ]);
 
-        var legend1 = Ext.create("GeoExt.VectorLegend", {
+        var legend1 = Ext.create("GeoExt.container.VectorLegend", {
             layerRecord: store.getAt(0)
         });
 
@@ -333,7 +333,7 @@
             new OpenLayers.Feature.Vector(new OpenLayers.Geometry.Point(2,2))
         ]);
         
-        var legend2 = Ext.create("GeoExt.VectorLegend", {
+        var legend2 = Ext.create("GeoExt.container.VectorLegend", {
             layerRecord: store.getAt(1)
         });
 

--- a/tests/container/WmsLegend.html
+++ b/tests/container/WmsLegend.html
@@ -22,7 +22,7 @@
 
         function loadMapPanel(render) {
             var renderTo = render === false ? null : "mappanel";
-            var mapPanel = Ext.create("GeoExt.MapPanel", {
+            var mapPanel = Ext.create("GeoExt.panel.Map", {
                 // panel options
                 id: "map-panel",
                 title: "GeoExt MapPanel",
@@ -47,7 +47,7 @@
             var layer1 = new OpenLayers.Layer.WMS("test", '/ows', {layers: ['a,b', 'c,d']});
             var layer2 = new OpenLayers.Layer.WMS("test", '/ows', {layers: ['x', 'y']});
             mapPanel.map.addLayers([layer1, layer2]);
-            l = Ext.create("GeoExt.WMSLegend", {
+            l = Ext.create("GeoExt.container.WmsLegend", {
                 renderTo: 'legendwms',
                 layerRecord: mapPanel.layers.getAt(1)
             });
@@ -59,7 +59,7 @@
             t.eq(url, expectedUrl, "GetLegendGraphic url is generated correctly");
             l.destroy();
 
-            l = Ext.create("GeoExt.WMSLegend", {
+            l = Ext.create("GeoExt.container.WmsLegend", {
                 renderTo: 'legendwms',
                 layerRecord: mapPanel.layers.getAt(2)
             });
@@ -78,7 +78,7 @@
             var l, url, expectedUrl;
             var mapPanel = loadMapPanel(false);
 
-            l = Ext.create("GeoExt.WMSLegend", {
+            l = Ext.create("GeoExt.container.WmsLegend", {
                 renderTo: 'legendwms',
                 baseParams: {FORMAT: 'image/png', foo: 'bar bar'},
                 useScaleParameter: false,
@@ -92,7 +92,7 @@
             t.eq(url, expectedUrl, "GetLegendGraphic url is generated correctly");
             l.destroy()
 
-            l = Ext.create("GeoExt.WMSLegend", {
+            l = Ext.create("GeoExt.container.WmsLegend", {
                 renderTo: 'legendwms',
                 useScaleParameter: false,
                 layerRecord: mapPanel.layers.getAt(0)
@@ -103,7 +103,7 @@
             t.eq(url, expectedUrl, "GetLegendGraphic url is generated correctly");
             l.destroy()
 
-            l = Ext.create("GeoExt.WMSLegend", {
+            l = Ext.create("GeoExt.container.WmsLegend", {
                 renderTo: 'legendwms',
                 layerRecord: mapPanel.layers.getAt(0)
             });

--- a/tests/panel/Legend.html
+++ b/tests/panel/Legend.html
@@ -54,7 +54,7 @@
             mapPanel.layers.getAt(0).set("legendURL", newUrl);
 
             var item = lp.getComponent(lp.getIdForLayer(mapPanel.map.layers[0]));
-            t.ok(item instanceof GeoExt.UrlLegend, "If legendURL is found in layerRecord, UrlLegend is chosen.")
+            t.ok(item instanceof GeoExt.container.UrlLegend, "If legendURL is found in layerRecord, UrlLegend is chosen.")
             var url = item.items.get(1).getEl().dom.src;
             t.eq(url, newUrl, "Update the image with the provided legendURL");
 


### PR DESCRIPTION
The namespaces were important to be the original ones, not the legacy ones.  It seems it prevented the loader to get the files in IE.

The panel/Legend test still fails in IE when run the first time, but after that.  It also looks like a trivial issue with the loader.
