### PR TITLE
Readd the private onBeforeAdd-method

### DIFF
--- a/src/GeoExt/panel/Map.js
+++ b/src/GeoExt/panel/Map.js
@@ -473,7 +473,19 @@ Ext.define('GeoExt.panel.Map', {
             }
         }
     },
-
+    
+    /**
+     * Check if an added item has to take separate actions
+     * to be added to the map.
+     * See e.g. the GeoExt.slider.Zoom or GeoExt.slider.LayerOpacity
+     * @private
+     */
+    onBeforeAdd: function(item) {
+        if(Ext.isFunction(item.addToMapPanel)) {
+            item.addToMapPanel(this);
+        }
+        this.callParent(arguments);
+    },
     
     /**
      * Private method called during the destroy sequence.


### PR DESCRIPTION
originally added in 9a01035e46750d363041 and accidentially removed in 7f0504f5f8ad0326afac6f44f3af5 to have the possibility of adding items such as the zoomslider to the mappanel. This fixes #81.
