### PR TITLE
Remove no longer needed and implemented listeners on the mappanel's map.

### DIFF
--- a/src/GeoExt/panel/Map.js
+++ b/src/GeoExt/panel/Map.js
@@ -208,8 +208,6 @@ Ext.define('GeoExt.panel.Map', {
         me.map.events.on({
             "moveend": me.onMoveend,
             "changelayer": me.onChangelayer,
-            "addlayer": me.onAddlayer,
-            "removelayer": me.onRemovelayer,
             scope: me
         });
         
@@ -500,8 +498,6 @@ Ext.define('GeoExt.panel.Map', {
             this.map.events.un({
                 "moveend": this.onMoveend,
                 "changelayer": this.onChangelayer,
-                "addlayer": this.onAddlayer,
-                "removelayer": this.onRemovelayer,
                 scope: this
             });
         }


### PR DESCRIPTION
The `panel.Map` tests pass in FF 12, Chrome 12 and IE 8 ('map.moveTo called exactly once' of `test_mappanel()`, fails there, but this is probably unrelated.)
