### PR TITLE
LayerStore.onLoad: wrong arguments 

### DIFF
--- a/examples/grid/feature-grid.js
+++ b/examples/grid/feature-grid.js
@@ -16,6 +16,7 @@ var mapPanel, store, gridPanel, mainPanel;
 
 Ext.require([
     'GeoExt.data.FeatureStore',
+    'GeoExt.grid.column.Symbolizer',
     'GeoExt.selection.FeatureModel',
     'Ext.grid.GridPanel',
     'Ext.layout.container.Border'
@@ -82,45 +83,17 @@ Ext.application({
         store = Ext.create('GeoExt.data.FeatureStore', {
             layer: vecLayer,
             fields: [
+                {
+                    name: 'symbolizer',
+                    convert: function(v, r) {
+                        return r.raw.layer.styleMap.createSymbolizer(r.raw, 'default');
+                    }
+                },
                 {name: 'name', type: 'string'},
                 {name: 'elevation', type: 'float'}
             ],
             autoLoad: true
         });
-
-        function getSymbolTypeFromFeature(feature) {
-            var type;
-            switch (feature.geometry.CLASS_NAME) {
-                case "OpenLayers.Geometry.MultiLineString":
-                case "OpenLayers.Geometry.LineString":
-                    type = 'Line';
-                    break;
-                case "OpenLayers.Geometry.Point":
-                    type = 'Point';
-                    break;
-                case "OpenLayers.Geometry.Polygon":
-                    type = 'Polygon';
-                    break;
-            }
-            return type;
-        }
-
-        function renderFeature(value, p, r) {
-            var id = Ext.id();
-            var feature = r.raw;
-
-            Ext.defer(function() {
-                var symbolizer = r.store.layer.styleMap.createSymbolizer(feature, 'default');
-                var renderer = Ext.create('GeoExt.FeatureRenderer', {
-                    renderTo: id,
-                    width: 12,
-                    height: 12,
-                    symbolType: getSymbolTypeFromFeature(feature),
-                    symbolizers: [symbolizer]
-                });
-            }, 25);
-            return Ext.String.format('<div id="{0}"></div>', id);
-        }
 
         // create grid panel configured with feature store
         gridPanel = Ext.create('Ext.grid.GridPanel', {
@@ -132,8 +105,8 @@ Ext.application({
                 menuDisabled: true,
                 sortable: false,
                 width: 30,
-                renderer: renderFeature,
-                dataIndex: 'fid'
+                xtype: 'gx_symbolizercolumn',
+                dataIndex: "symbolizer"
             },{
                 header: "Name",
                 width: 200,

--- a/src/GeoExt/grid/column/Symbolizer.js
+++ b/src/GeoExt/grid/column/Symbolizer.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2008-2012 The Open Source Geospatial Foundation
+ *
+ * Published under the BSD license.
+ * See https://github.com/geoext/geoext2/blob/master/license.txt for the full text
+ * of the license.
+ */
+
+/**
+ * @class GeoExt.grid.column.Symbolizer
+ */
+Ext.define('GeoExt.grid.column.Symbolizer', {
+    extend: 'Ext.grid.column.Column',
+    alternateClassName: 'GeoExt.grid.SymbolizerColumn',
+    alias: ['widget.gx_symbolizercolumn'],
+    require: ['GeoExt.FeatureRenderer'],
+
+    defaultRenderer: function(value, meta, record) {
+        if (value) {
+            var id = Ext.id();
+            window.setTimeout(function() {
+                var renderer = Ext.create('GeoExt.FeatureRenderer', {
+                    renderTo: id,
+                    symbolizers: value instanceof Array ? value : [value]
+                });
+            }, 0);
+            meta.css = "gx-grid-symbolizercol";
+            return Ext.String.format('<div id="{0}"></div>', id);
+        }
+    }
+});

--- a/tests/grid/column/Symbolizer.html
+++ b/tests/grid/column/Symbolizer.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html debug="true">
+  <head>
+    <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css">
+    <script type="text/javascript" src="http://openlayers.org/api/2.12-rc3/OpenLayers.js"></script>
+    <script type="text/javascript" src="http://cdn.sencha.io/ext-4.1.0-gpl/ext-all-debug.js"></script>
+
+    <script type="text/javascript">
+
+        Ext.Loader.setConfig({
+            enabled: true,
+            disableCaching: false,
+            paths: {
+                "GeoExt": "../../../src/GeoExt"
+            }
+        });
+
+        Ext.require([
+            'GeoExt.grid.column.Symbolizer'
+        ]);
+
+        function test_renderer(t) {
+            t.plan(4);
+
+            var meta = {},
+                value = {fillColor: "red", stroke: false},
+                column = Ext.create('GeoExt.grid.column.Symbolizer'),
+                markup = column.renderer(value, meta),
+                el = document.createElement("div");
+            document.body.appendChild(el);
+            el.innerHTML = markup;
+
+            t.eq(meta.css, "gx-grid-symbolizercol", "css class set correctly");
+
+            t.delay_call(1, function() {
+                var renderers = Ext.ComponentQuery.query('gx_symbolizercolumn');
+
+                t.eq(renderers.length, 1, "Exactly one instance created");
+                var renderer = renderers[0];
+
+                t.ok(renderer instanceof GeoExt.grid.column.Symbolizer, "FeatureRenderer created");
+                t.ok(el.childNodes.length > 0, "component added to markup");
+                renderer.destroy();
+                document.body.removeChild(el);
+            });
+        }
+    </script>
+
+  <body>
+  </body>
+</html>

--- a/tests/list-tests.html
+++ b/tests/list-tests.html
@@ -7,6 +7,7 @@
   <li>container/WmsLegend.html</li>
   <li>container/VectorLegend.html</li>
   <li>selection/FeatureModel.html</li>
+  <li>grid/column/Symbolizer.html</li>
   <li>slider/Zoom.html</li>
   <li>slider/LayerOpacity.html</li>
   <li>state/PermalinkProvider.html</li>


### PR DESCRIPTION
The arguments passed to the callback are: `store`, `records`and `successful`.  There is no `options` object anymore.

See: http://docs.sencha.com/ext-js/4-1/#!/api/Ext.data.Store-event-load
