### PR TITLE
OWS stores inherit from the base OwsStore

### DIFF
--- a/src/GeoExt/data/WfsCapabilitiesLayerStore.js
+++ b/src/GeoExt/data/WfsCapabilitiesLayerStore.js
@@ -8,6 +8,7 @@
 
 /*
  * @include GeoExt/data/reader/WfsCapabilities.js
+ * @requires GeoExt/data/OwsStore.js
  */
 
 /**

--- a/src/GeoExt/data/WmsCapabilitiesLayerStore.js
+++ b/src/GeoExt/data/WmsCapabilitiesLayerStore.js
@@ -8,6 +8,7 @@
 
 /*
  * @include GeoExt/data/reader/WmsCapabilities.js
+ * @requires GeoExt/data/OwsStore.js
  */
 
 /**

--- a/src/GeoExt/data/WmsDescribeLayerStore.js
+++ b/src/GeoExt/data/WmsDescribeLayerStore.js
@@ -8,6 +8,7 @@
 
 /*
  * @include GeoExt/data/reader/WmsDescribeLayer.js
+ * @requires GeoExt/data/OwsStore.js
  */
 
 /**


### PR DESCRIPTION
Simplify the OWS based stores (WMSCaps, WFSCaps, WMSDescLayer, Attribute) to use the base OWS class. All tests pass & examples work as expected
