### PR TITLE
Fixed test for printpreviewmap on chrome, firefox still problematic

### DIFF
--- a/src/GeoExt/panel/PrintMap.js
+++ b/src/GeoExt/panel/PrintMap.js
@@ -244,6 +244,10 @@ Ext.define('GeoExt.panel.PrintMap', {
         this.printPage.on("change", this.fitZoom, this);
         this.printProvider.on("layoutchange", this.syncSize, this);
         this.map.events.register("moveend", this, this.updatePage);
+        this.on("resize", function() {
+            this.doComponentLayout();
+            this.map.updateSize();
+        }, this);
         
         this.printPage.fit(this.sourceMap);
 


### PR DESCRIPTION
fixed a problem with the map not properly updating its size, makes the tests run ok in chrome, firefox still problematic because somewhy the center doesnt get applied correctly
