### PR TITLE
example app/simple (trivial) GX->CF

### DIFF
--- a/examples/app/simple/app.js
+++ b/examples/app/simple/app.js
@@ -14,12 +14,12 @@ Ext.Loader.setConfig({
 });
 
 /**
- * GX.app
+ * CF.app
  * A MVC application demo that uses GeoExt and Ext components to display
  * geospatial data.
  */
 Ext.application({
-    name: 'GX',
+    name: 'CF',
     appFolder: 'app',
     controllers: [
         'Map'

--- a/examples/app/simple/app/controller/Map.js
+++ b/examples/app/simple/app/controller/Map.js
@@ -2,7 +2,7 @@
  * Map controller
  * Used to manage map layers and showing their related views
  */
-Ext.define('GX.controller.Map', {
+Ext.define('CF.controller.Map', {
     extend: 'Ext.app.Controller',
 
     models: ['Summit'],
@@ -22,7 +22,7 @@ Ext.define('GX.controller.Map', {
         });
 
         this.control({
-            'gxapp_map': {
+            'cf_mappanel': {
                 'beforerender': this.onMapPanelBeforeRender
             }
         }, this);

--- a/examples/app/simple/app/model/Summit.js
+++ b/examples/app/simple/app/model/Summit.js
@@ -1,7 +1,7 @@
 /**
  * Model for a summit
  */
-Ext.define('GX.model.Summit', {
+Ext.define('CF.model.Summit', {
     extend: 'Ext.data.Model',
     fields: [
         {

--- a/examples/app/simple/app/store/Summits.js
+++ b/examples/app/simple/app/store/Summits.js
@@ -1,8 +1,8 @@
 /**
  * The store used for summits
  */
-Ext.define('GX.store.Summits', {
+Ext.define('CF.store.Summits', {
     extend: 'GeoExt.data.FeatureStore',
-    model: 'GX.model.Summit',
+    model: 'CF.model.Summit',
     autoLoad: false
 });

--- a/examples/app/simple/app/view/Header.js
+++ b/examples/app/simple/app/view/Header.js
@@ -2,15 +2,16 @@
  * The application header displayed at the top of the viewport
  * @extends Ext.Component
  */
-Ext.define('GX.view.Header', {
+Ext.define('CF.view.Header', {
     extend: 'Ext.Component',
 
     dock: 'top',
-    baseCls: 'app-header',
+    baseCls: 'cf-header',
 
     initComponent: function() {
         Ext.applyIf(this, {
-            html: 'MVC simple application example called GX'
+            html: 'MVC simple application example called CF ' +
+                '(Cartography Framework)'
         });
 
         this.callParent(arguments);

--- a/examples/app/simple/app/view/Map.js
+++ b/examples/app/simple/app/view/Map.js
@@ -3,14 +3,14 @@
  * and stuff.
  * @extends GeoExt.panel.Map
  */
-Ext.define('GX.view.Map', {
+Ext.define('CF.view.Map', {
     // Ext.panel.Panel-specific options:
     extend: 'GeoExt.panel.Map',
-    alias : 'widget.gxapp_map',
+    alias : 'widget.cf_mappanel',
     requires: [
         'Ext.window.MessageBox',
         'GeoExt.Action',
-        'GX.view.help.Action'
+        'CF.view.help.Action'
     ],
     border: 'false',
     layout: 'fit',
@@ -75,7 +75,7 @@ Ext.define('GX.view.Map', {
 
         // Help action
         items.push(
-            Ext.create('Ext.button.Button', Ext.create('GX.view.help.Action', {
+            Ext.create('Ext.button.Button', Ext.create('CF.view.help.Action', {
                 windowContentEl: "help"
             }))
         );

--- a/examples/app/simple/app/view/Viewport.js
+++ b/examples/app/simple/app/view/Viewport.js
@@ -2,17 +2,17 @@
  * The main application viewport, which displays the whole application
  * @extends Ext.Viewport
  */
-Ext.define('GX.view.Viewport', {
+Ext.define('CF.view.Viewport', {
     extend: 'Ext.Viewport',
     layout: 'fit',
 
     requires: [
         'Ext.layout.container.Border',
         'Ext.resizer.Splitter',
-        'GX.view.Header',
-        'GX.view.Map',
-        'GX.view.summit.Chart',
-        'GX.view.summit.Grid'
+        'CF.view.Header',
+        'CF.view.Map',
+        'CF.view.summit.Chart',
+        'CF.view.summit.Grid'
     ],
 
     initComponent: function() {
@@ -24,10 +24,10 @@ Ext.define('GX.view.Viewport', {
                 border: false,
                 layout: 'border',
                 dockedItems: [
-                    Ext.create('GX.view.Header')
+                    Ext.create('CF.view.Header')
                 ],
                 items: [{
-                    xtype: 'gxapp_map'
+                    xtype: 'cf_mappanel'
                 }, {
                     xtype: 'panel',
                     region: 'center',
@@ -38,9 +38,9 @@ Ext.define('GX.view.Viewport', {
                         align: 'stretch'
                     },
                     items: [
-                        Ext.create('GX.view.summit.Grid'),
+                        Ext.create('CF.view.summit.Grid'),
                         {xtype: 'splitter'},
-                        Ext.create('GX.view.summit.Chart')
+                        Ext.create('CF.view.summit.Chart')
                     ]
                 }]
             }]

--- a/examples/app/simple/app/view/help/Action.js
+++ b/examples/app/simple/app/view/help/Action.js
@@ -2,10 +2,10 @@
  * Help Action
  * @extends Ext.Action
  */
-Ext.define('GX.view.help.Action', {
+Ext.define('CF.view.help.Action', {
     extend: 'Ext.Action',
-    alias : 'widget.gxapp_helpaction',
-    requires: ['GX.view.help.Window'],
+    alias : 'widget.cf_helpaction',
+    requires: ['CF.view.help.Window'],
 
     /**
      * @property {String} windowContentEl
@@ -27,7 +27,7 @@ Ext.define('GX.view.help.Action', {
     /**
      * @private
      *
-     * Create a GX.view.help.Action instance.
+     * Create a CF.view.help.Action instance.
      *
      * @param {Object} config (optional) Config object.
      *
@@ -36,7 +36,7 @@ Ext.define('GX.view.help.Action', {
         Ext.apply(config, {
             handler: function() {
                 if (!this._window) {
-                    this._window = Ext.create('GX.view.help.Window', {
+                    this._window = Ext.create('CF.view.help.Window', {
                         contentEl: this.windowContentEl
                     });
                 }

--- a/examples/app/simple/app/view/help/Window.js
+++ b/examples/app/simple/app/view/help/Window.js
@@ -2,12 +2,12 @@
  * Help Window with static content using 'contentEl' property.
  * @extends Ext.window.Window
  */
-Ext.define('GX.view.help.Window', {
+Ext.define('CF.view.help.Window', {
     extend: 'Ext.window.Window',
-    alias : 'widget.gxapp_helpwindow',
+    alias : 'widget.cf_helpwindow',
     initComponent: function() {
         Ext.apply(this, {
-            bodyCls: "gxapp-helpwindow",
+            bodyCls: "cf-helpwindow",
             closeAction: "hide",
             layout: 'fit',
             maxWidth: 600,

--- a/examples/app/simple/app/view/summit/Chart.js
+++ b/examples/app/simple/app/view/summit/Chart.js
@@ -1,4 +1,4 @@
-Ext.define('GX.view.summit.Chart', {
+Ext.define('CF.view.summit.Chart', {
     extend: 'Ext.chart.Chart',
     alias : 'widget.summitchart',
     requires: ['Ext.chart.*'],
@@ -35,7 +35,7 @@ Ext.define('GX.view.summit.Chart', {
                 fill: true,
                 listeners: {
                     itemmousedown: function(e) {
-                        GX.view.summit.Grid.selectionModel.select(e.storeItem);
+                        CF.view.summit.Grid.selectionModel.select(e.storeItem);
                     }
                 },
                 highlight: {

--- a/examples/app/simple/app/view/summit/Grid.js
+++ b/examples/app/simple/app/view/summit/Grid.js
@@ -2,7 +2,7 @@
  * The grid in which summits are displayed
  * @extends Ext.grid.Panel
  */
-Ext.define('GX.view.summit.Grid' ,{
+Ext.define('CF.view.summit.Grid' ,{
     extend: 'Ext.grid.Panel',
     alias : 'widget.summitgrid',
     requires: [
@@ -47,6 +47,6 @@ Ext.define('GX.view.summit.Grid' ,{
         this.getSelectionModel().autoPanMapOnSelection = true;
         this.callParent(arguments);
         // store singleton selection model instance
-        GX.view.summit.Grid.selectionModel = this.getSelectionModel();
+        CF.view.summit.Grid.selectionModel = this.getSelectionModel();
     }
 });

--- a/examples/app/simple/resources/css/cf.css
+++ b/examples/app/simple/resources/css/cf.css
@@ -1,4 +1,4 @@
-.app-header {
+.cf-header {
     background-color: #252F49;
     border-bottom: 1px solid #16191D;
     color: white;
@@ -10,15 +10,15 @@
     
 }
 
-.gxapp-helpwindow {
+.cf-helpwindow {
     background-color: #FFFFFF;
     padding: 5px;
 }
 
-.gxapp-helpwindow div.cascade {
+.cf-helpwindow div.cascade {
     padding: 0 0 0 5px;
 }
 
-.gxapp-helpwindow h2 {
+.cf-helpwindow h2 {
     margin: 2px 0 0 0;
 }

--- a/examples/app/simple/simple-dev.html
+++ b/examples/app/simple/simple-dev.html
@@ -1,10 +1,10 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
     <head>
-        <title>MVC simple application example called GX</title>
+        <title>MVC simple application example called CF (Cartography Framework)</title>
         <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css" />
         <link rel="stylesheet" type="text/css" href="http://openlayers.org/api/2.12-rc3/theme/default/style.css" />
-        <link rel="stylesheet" type="text/css" href="resources/css/gx.css" />
+        <link rel="stylesheet" type="text/css" href="resources/css/cf.css" />
 
         <!-- Include OpenLayers.  Isn't managed by Ext.Loader -->
         <script src="http://openlayers.org/api/2.12-rc3/OpenLayers.js"></script>

--- a/examples/app/simple/simple.html
+++ b/examples/app/simple/simple.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
     <head>
-        <title>MVC simple application example called GX</title>
+        <title>MVC simple application example called CF (Cartography Framework)</title>
         <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css" />
         <link rel="stylesheet" type="text/css" href="http://openlayers.org/api/2.12-rc3/theme/default/style.css" />
         <link rel="stylesheet" type="text/css" href="resources/css/gx.css" />


### PR DESCRIPTION
Trivial app/simple example change.  Application name was GX, which was too close to GeoExt (it uses gx_ as namespace prefix for aliases).  So, to avoid confusion, CF is now used in the example instead (which means Cartography Framework) :)
