### PR TITLE
Add the style store and associated models

### DIFF
--- a/examples/stylegrid/style-grid.html
+++ b/examples/stylegrid/style-grid.html
@@ -1,0 +1,33 @@
+<html>
+<head>
+    <title>GeoExt StyleReader</title>
+        <link rel="stylesheet" type="text/css" href="http://cdn.sencha.io/ext-4.1.0-gpl/resources/css/ext-all.css">
+        <link rel="stylesheet" type="text/css" href="../../resources/css/tree.css">
+        <script type="text/javascript" charset="utf-8" src="http://cdn.sencha.io/ext-4.1.0-gpl/ext-dev.js"></script>
+
+        <!-- You should definitely consider using a custom single-file version of OpenLayers -->
+        <script src="http://openlayers.org/api/2.12-rc3/OpenLayers.js"></script>
+
+        <script type="text/javascript" src="../loader.js"></script>
+        <script type="text/javascript" src="style-grid.js"></script>
+
+</head>
+<body>
+    <h1>GeoExt.data.StyleReader</h1>
+    <p>The StyleReader populates a store with records representing the rules
+    of a Style or the entries of a ColorMap, so they can easily be shown in a
+    grid.</p>
+
+    <p>The js is not minified so it is readable. See <a href="style-grid.js">style-grid.js</a>.</p>
+    <p>This grid shows the rules of a Style for a vector layer. Drag&amp;Drop is
+    enabled, labels are editable and filters can be edited inline using CQL
+    syntax:</p>
+    <div id="vectorgrid"></div>
+    <br>
+    <p>This grid shows the entries of the ColorMap of a RasterSymbolizer.
+    The column configuration is the same as for the vector grid above. Label and
+    filter (quantity) are editable, and the quantities will always be sorted in
+    ascending order:</p>
+    <div id="rastergrid"></div>
+</body>
+</html>

--- a/examples/stylegrid/style-grid.js
+++ b/examples/stylegrid/style-grid.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2008-2012 The Open Source Geospatial Foundation
+ * 
+ * Published under the BSD license.
+ * See http://svn.geoext.org/core/trunk/geoext/license.txt for the full text
+ * of the license.
+ */
+
+/* api: example[style-grid]
+ *  Style Reader
+ *  ----------------
+ *  Rendering and basic editing of SLD rules or an SLD ColorMap with a store
+ *  created using GeoExt.data.StyleReader.
+ */
+
+var rasterSld = '<?xml version="1.0" encoding="ISO-8859-1"?><StyledLayerDescriptor version="1.0.0" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd"><NamedLayer><Name>rain</Name><UserStyle><Name>rain</Name><Title>Rain distribution</Title><FeatureTypeStyle><Rule><RasterSymbolizer><Opacity>1.0</Opacity><ColorMap><ColorMapEntry color="#FF0000" quantity="0" /><ColorMapEntry color="#FFFFFF" quantity="100"/><ColorMapEntry color="#00FF00" quantity="2000"/><ColorMapEntry color="#0000FF" quantity="5000"/></ColorMap></RasterSymbolizer></Rule></FeatureTypeStyle></UserStyle></NamedLayer></StyledLayerDescriptor>';
+var vectorSld = '<?xml version="1.0" encoding="ISO-8859-1"?><StyledLayerDescriptor version="1.0.0" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd"><NamedLayer><Name>USA states population</Name><UserStyle><Name>population</Name><Title>Population in the United States</Title><Abstract>A sample filter that filters the United States into threecategories of population, drawn in different colors</Abstract><FeatureTypeStyle><Rule><Title>&lt; 2M</Title><ogc:Filter><ogc:PropertyIsLessThan> <ogc:PropertyName>PERSONS</ogc:PropertyName> <ogc:Literal>2000000</ogc:Literal></ogc:PropertyIsLessThan></ogc:Filter><PolygonSymbolizer> <Fill><!-- CssParameters allowed are fill (the color) and fill-opacity --><CssParameter name="fill">#4DFF4D</CssParameter><CssParameter name="fill-opacity">0.7</CssParameter> </Fill> </PolygonSymbolizer></Rule><Rule><Title>2M - 4M</Title><ogc:Filter><ogc:PropertyIsBetween><ogc:PropertyName>PERSONS</ogc:PropertyName><ogc:LowerBoundary><ogc:Literal>2000000</ogc:Literal></ogc:LowerBoundary><ogc:UpperBoundary><ogc:Literal>4000000</ogc:Literal></ogc:UpperBoundary></ogc:PropertyIsBetween></ogc:Filter><PolygonSymbolizer> <Fill><!-- CssParameters allowed are fill (the color) and fill-opacity --><CssParameter name="fill">#FF4D4D</CssParameter><CssParameter name="fill-opacity">0.7</CssParameter> </Fill> </PolygonSymbolizer></Rule><Rule><Title>&gt; 4M</Title><!-- like a linesymbolizer but with a fill too --><ogc:Filter><ogc:PropertyIsGreaterThan> <ogc:PropertyName>PERSONS</ogc:PropertyName> <ogc:Literal>4000000</ogc:Literal></ogc:PropertyIsGreaterThan></ogc:Filter><PolygonSymbolizer> <Fill><!-- CssParameters allowed are fill (the color) and fill-opacity --><CssParameter name="fill">#4D4DFF</CssParameter><CssParameter name="fill-opacity">0.7</CssParameter> </Fill> </PolygonSymbolizer></Rule><Rule><Title>Boundary</Title><LineSymbolizer><Stroke><CssParameter name="stroke-width">0.2</CssParameter></Stroke></LineSymbolizer><TextSymbolizer><Label><ogc:PropertyName>STATE_ABBR</ogc:PropertyName></Label><Font><CssParameter name="font-family">Times New Roman</CssParameter><CssParameter name="font-style">Normal</CssParameter><CssParameter name="font-size">14</CssParameter></Font><LabelPlacement><PointPlacement><AnchorPoint><AnchorPointX>0.5</AnchorPointX><AnchorPointY>0.5</AnchorPointY></AnchorPoint></PointPlacement></LabelPlacement></TextSymbolizer></Rule> </FeatureTypeStyle></UserStyle></NamedLayer></StyledLayerDescriptor>';
+
+var format = new OpenLayers.Format.SLD({multipleSymbolizers: true});
+
+var vectorStyle = format.read(vectorSld).namedLayers["USA states population"].userStyles[0];
+var rasterStyle = format.read(rasterSld).namedLayers["rain"].userStyles[0];
+
+var vectorGrid, rasterGrid;
+
+Ext.require([
+    'GeoExt.data.StyleStore',
+    //'GeoExt.grid.column.Symbolizer',
+    'Ext.grid.GridPanel',
+    'Ext.grid.plugin.RowEditing'
+]);
+
+Ext.application({
+    name: 'Feature Grid - GeoExt2',
+    launch: function() {
+    
+    var columns = [
+        //{dataIndex: "symbolizers", width: 26, xtype: "gx_symbolizercolumn"},
+        {header: "Label", dataIndex: "label", editor: {xtype: "textfield"}},
+        {header: "Filter", dataIndex: "filter", editor: {xtype: "textfield"}}
+    ];
+    
+        
+    vectorGrid = Ext.create('Ext.grid.GridPanel',{
+        width: 220,
+        height: 115,
+        columns: columns.concat(),
+        viewConfig: {autoFill: true},
+        plugins: [
+            Ext.create('Ext.grid.plugin.RowEditing', {
+                clicksToEdit: 1
+            })
+        ],
+        store: Ext.create('GeoExt.data.StyleStore',
+            {data: vectorStyle }
+        ),
+        renderTo: "vectorgrid"
+        /*enableDragDrop: true,
+        ddGroup: "vgrid",
+        listeners: {
+            //afteredit: function(e) {e.grid.store.commitChanges();},
+            render: function makeDD(grid) {
+                store = grid.store;
+                new Ext.dd.DropTarget(grid.getView().mainBody, {
+                    ddGroup : "vgrid",
+                    notifyDrop: function(dd, e, data){
+                        var sm = grid.getSelectionModel();
+                        var rows = sm.getSelections();
+                        var cindex = dd.getDragData(e).rowIndex;
+                        if (sm.hasSelection()) {
+                            for (var i=0, ii=rows.length; i<ii; ++i) {
+                                store.remove(store.getById(rows[i].id));
+                                store.insert(cindex,rows[i]);
+                                store.commitChanges();
+                            }
+                            sm.selectRecords(rows);
+                        }  
+                    }
+                });
+            },
+            scope: this
+        }*/
+    });
+    rasterGrid = Ext.create('Ext.grid.GridPanel',{
+        width: 220,
+        height: 115,
+        columns: columns.concat(),
+        viewConfig: {autoFill: true},
+        selType: 'rowmodel',
+        plugins: [
+            Ext.create('Ext.grid.plugin.RowEditing', {
+                clicksToEdit: 1
+            })
+        ],
+        store: Ext.create('GeoExt.data.StyleStore',
+            {data: rasterStyle.rules[0].symbolizers[0]}
+        ), 
+        renderTo: "rastergrid"//,
+        //listeners: {
+        //    afteredit: function(e) {e.grid.store.commitChanges();}
+        //}
+    });
+}
+});

--- a/src/GeoExt/data/RasterStyleModel.js
+++ b/src/GeoExt/data/RasterStyleModel.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2012 The Open Source Geospatial Foundation
+ *
+ * Published under the BSD license.
+ * See https://github.com/geoext/geoext2/blob/master/license.txt for the full text
+ * of the license.
+ */
+
+/*
+ * @include OpenLayers/Symbolizer/Raster.js
+ */
+
+/**
+ * @class GeoExt.data.RasterStyleModel
+ * <p>A specific model for Raster Symbolizer classifications<p>
+ *
+ * Preconfigured with an Ajax proxy and a JSON reader
+ * 
+ */
+
+Ext.define('GeoExt.data.RasterStyleModel',{
+        extend: 'Ext.data.Model',
+        requires : ['Ext.data.JsonReader'],
+        idProperty: "filter",
+        fields: [
+            {name: "symbolizers", mapping: function(v) {
+                return {
+                    fillColor: v.color,
+                    fillOpacity: v.opacity,
+                    stroke: false
+                };
+            }, defaultValue: null},
+            {name: "filter", mapping: "quantity", type: "float"},
+            {name: "label", mapping: function(v) {
+                // fill label with quantity if empty
+                return v.label || v.quantity;
+            }}
+        ],
+        proxy: {
+            type: 'memory',
+            reader: {
+                type: 'json',
+                root: 'colorMap'
+            }
+        }
+});

--- a/src/GeoExt/data/StyleStore.js
+++ b/src/GeoExt/data/StyleStore.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2012 The Open Source Geospatial Foundation
+ * 
+ * Published under the BSD license.
+ * See http://svn.geoext.org/core/trunk/geoext/license.txt for the full text
+ * of the license.
+ */
+
+/**
+ *  A smart store that creates records for client-side rendered legends. If
+ *  its store is configured with an {OpenLayers.Style2} instance as `data`,
+ *  each record will represent a Rule of the Style, and the store will be
+ *  configured with `symbolizers` (Array of {OpenLayers.Symbolizer}),
+ *  `filter` ({OpenLayers.Filter}), `label` (String, the rule's title),
+ *  `name` (String), `description` (String), `elseFilter` (Boolean),
+ *  `minScaleDenominator` (Number) and `maxScaleDenominator` (Number)
+ *  fields. If the store's `data` is an {OpenLayers.Symbolizer.Raster}
+ *  instance, records will represent its ColorMap entries, and the available
+ *  fields will only be `symbolizers` (object literal with `color` and
+ *  `opacity` properties from the ColorMapEntry, and stroke set to false),
+ *  `filter` (String, the ColorMapEntry's quantity) and `label` (String).
+ *
+ *
+ *  NOTE:
+ *
+ *      Calling `commitChanges` on the store that is populated with
+ *      this reader will fail with OpenLayers 2.11 - it requires at least
+ *      revision
+ *      https://github.com/openlayers/openlayers/commit/1db5ac3cbe874317968f78832901d6ef887ecca6
+ *      from 2011-11-28 of OpenLayers.
+ *
+ *  Example:
+ *  Sample code to create a store that reads from an {OpenLayers.Style2}
+ *  object:
+ *  
+ <pre><code>
+ *
+ *      var store = Ext.create('GeoExt.data.StyleStore',{
+ *          data: myStyle // OpenLayers.Style2 or OpenLayers.Symbolizer.Raster
+ *      });
+ </code></pre>
+ */
+Ext.define('GeoExt.data.StyleStore', {
+    extend: 'Ext.data.Store',
+    requires: [
+        'GeoExt.data.VectorStyleModel',
+        'GeoExt.data.RasterStyleModel'
+    ],
+    alias: 'store.gx_style',
+    sorters: [{
+        property: 'filter',
+        direction: 'ASC'
+    }],
+
+    constructor: function(config){
+        config = Ext.apply({}, config);
+        if(config.data && !config.model){
+            if (config.data instanceof OpenLayers.Symbolizer.Raster) {
+                config.model = 'GeoExt.data.RasterStyleModel';
+            } else {
+                config.model = 'GeoExt.data.VectorStyleModel';
+            }            
+        }
+        this.callParent([config]);
+    }
+});

--- a/src/GeoExt/data/VectorStyleModel.js
+++ b/src/GeoExt/data/VectorStyleModel.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2012 The Open Source Geospatial Foundation
+ *
+ * Published under the BSD license.
+ * See https://github.com/geoext/geoext2/blob/master/license.txt for the full text
+ * of the license.
+ */
+
+/*
+ * @include OpenLayers/Format/CQL.js
+ */
+
+/**
+ * @class GeoExt.data.VectorStyleModel
+ * <p>A specific model for CQL Style Rules<p>
+ *
+ * Preconfigured with an Ajax proxy and a JSON reader
+ */
+
+Ext.define('GeoExt.data.VectorStyleModel', {
+    extend : 'Ext.data.Model',
+    requires : ['Ext.data.JsonReader'],
+    fields : [
+        {name: "elseFilter", defaultValue: null},
+        {name: "symbolizers", defaultValue: null}, 
+        {name : "label", mapping : "title" },
+        {name: "filter", convertor: function(filter){
+            if (typeof filter === "string") {
+                filter = filter ? OpenLayers.Format.CQL.prototype.read(filter) : null;
+            }
+            return filter;}
+        }, 
+        "name", 
+        "description", 
+        "minScaleDenominator", 
+        "maxScaleDenominator"
+    ],
+    proxy : {
+        type : 'memory',
+        reader : {
+            type : 'json',
+            root : "rules"
+        }
+    }
+});


### PR DESCRIPTION
Add the style store as a replacement for the `data.StyleReader` from GeoExt 1.
No tests and a not quite working example
