### PR TITLE
fix data.feature.Reader - record internalId set instead of 'id' data

### DIFF
--- a/src/GeoExt/data/reader/Feature.js
+++ b/src/GeoExt/data/reader/Feature.js
@@ -64,7 +64,7 @@ Ext.define('GeoExt.data.reader.Feature', {
 
             // newly inserted features need to be made into phantom records
             var id = (feature.state === OpenLayers.State.INSERT) ? undefined : feature.id;
-            convertedValues['id'] = id;
+            record.internalId = id;
         }
 
         return records;


### PR DESCRIPTION
If I understand correctly, in 1.1 that line created a new record instance using the feature.id if it was set, or 'undefined' if state was INSERT.

In 2.0, the convertedValues is the record data property, so setting 'id' here doesn't seem okay.  Plus, in my case, I have an 'id' field and its value is always overriden by the feature.id value.

I'm not sure if setting the record.internalId is the right way to go, so please review.