### PR TITLE
Remove legacy rowselect/unselect event bindings.

### DIFF
--- a/src/GeoExt/selection/FeatureModel.js
+++ b/src/GeoExt/selection/FeatureModel.js
@@ -198,8 +198,6 @@ Ext.define('GeoExt.selection.FeatureModel', {
                     scope: this
                 });
             }
-            this.on("rowselect", this.rowSelected, this);
-            this.on("rowdeselect", this.rowDeselected, this);
             this.bound = true;
         }
         return this.selectControl;
@@ -222,8 +220,6 @@ Ext.define('GeoExt.selection.FeatureModel', {
                     scope: this
                 });
             }
-            this.un("rowselect", this.rowSelected, this);
-            this.un("rowdeselect", this.rowDeselected, this);
             if (this.autoActivateControl) {
                 selectControl.deactivate();
             }


### PR DESCRIPTION
These are now unneeded, as the private method "onSelectChange" now handles the
respective logic.

The `GeoExt.selection.FeatureModel` tests pass in Chrome  21 on Ubuntu.

Please review.
