### PR TITLE
Fixing IE issue with global scope in VectorLegend.

### DIFF
--- a/src/GeoExt/container/VectorLegend.js
+++ b/src/GeoExt/container/VectorLegend.js
@@ -420,7 +420,7 @@ Ext.define('GeoExt.container.VectorLegend', {
         var types = [this.symbolType, "Point", "Line", "Polygon"];
         var type, haveType;
         var symbolizers = rule.symbolizers;
-        var i;
+        var i, len;
         if (!symbolizers) {
             // TODO: remove this when OpenLayers.Symbolizer is used everywhere
             var symbolizer = rule.symbolizer;


### PR DESCRIPTION
The variable "len" was in a global scope, which causes an error in IE (tested in IE 9). Fixed by giving "len" a private scope.
