### PR TITLE
Fix to tree/Column.js losing scope on render

### DIFF
--- a/src/GeoExt/tree/Column.js
+++ b/src/GeoExt/tree/Column.js
@@ -18,14 +18,12 @@ Ext.define('GeoExt.tree.Column', {
 
     initComponent: function() {
         var me = this;
-
         me.callParent();
+    },
+    
+    treeRenderer: function(value, metaData, record, rowIdx, colIdx, store, view) {
 
-        var parentRenderer = me.renderer;
-
-        this.renderer = function(value, metaData, record, rowIdx, colIdx, store, view) {
-
-            var buf   = [parentRenderer(value, metaData, record, rowIdx, colIdx, store, view)];
+            var buf   = [this.callParent(arguments)];
 
             // Replace all base layers from checkbox to radio
             if(record.get('checkedGroup')) {
@@ -41,8 +39,6 @@ Ext.define('GeoExt.tree.Column', {
             }
 
             return buf.join('');
-        };
-
     },
 
     defaultRenderer: function(value) {


### PR DESCRIPTION
Changed Column.js to override the treeRenderer with inheritance rather than using the prior method.  This stops the render method losing scope on a render call
