### PR TITLE
Compatibility fix for ExtJS 4.2

### DIFF
--- a/src/GeoExt/panel/Map.js
+++ b/src/GeoExt/panel/Map.js
@@ -123,6 +123,17 @@ Ext.define('GeoExt.panel.Map', {
     map: null,
 
     /**
+     * @cfg {OpenLayers.Map/Object} layout
+     * In order for child items to be correctly sized and positioned,
+     * typically a layout manager must be specified through the layout configuration option.
+     */
+    /**
+     * @property {OpenLayers.Map/Object} layout
+     * A layout or layout configuration.
+     */
+    layout: 'fit',
+
+    /**
      * @cfg {GeoExt.data.LayerStore/OpenLayers.Layer[]} layers
      * The layers provided here will be added to this Map's
      * {@link #property-map}.


### PR DESCRIPTION
When geoext2 is used with ExtJS 4.2, the config option `layout: 'fit'` is absolutely required, otherwise the map won't even show up.

If you run into this issue, it is very hard to spot. So it makes sense to fix this not just in our application, but also on geoext2 side, by using `layout: 'fit'` by default in the main panel class. The attached change does exactly that.
