### PR TITLE
Replaced native indexOf() with Ext.Array.indexOf()

### DIFF
--- a/src/GeoExt/data/reader/Attribute.js
+++ b/src/GeoExt/data/reader/Attribute.js
@@ -174,7 +174,7 @@ Ext.define('GeoExt.data.reader.Attribute', {
             if(typeof matches == "string") {
                 ignore = (matches === value);
             } else if(matches instanceof Array) {
-                ignore = (matches.indexOf(value) > -1);
+                ignore = (Ext.Array.indexOf(matches, value) > -1);
             } else if(matches instanceof RegExp) {
                 ignore = (matches.test(value));
             }


### PR DESCRIPTION
Replaced native indexOf() method with Ext.Array.indexOf() to gain compatability with IE8.
