### PR TITLE
Make all tests pass again.

### DIFF
--- a/src/GeoExt/panel/PrintMap.js
+++ b/src/GeoExt/panel/PrintMap.js
@@ -68,7 +68,11 @@ var mapPanel = new GeoExt.MapPanel({
  */
 Ext.define('GeoExt.panel.PrintMap', {
     extend : 'GeoExt.panel.Map',
-    requires: ['GeoExt.data.PrintPage'],
+    requires: [
+        'Ext.data.Store',
+        'GeoExt.data.MapfishPrintProvider',
+        'GeoExt.data.PrintPage'
+    ],
     alias : 'widget.gx_printmappanel',
     alternateClassName : 'GeoExt.PrintMapPanel',
 
@@ -219,7 +223,6 @@ Ext.define('GeoExt.panel.PrintMap', {
         }, this);
 
         this.extent = this.sourceMap.getExtent();
-
         this.callParent(arguments);
     },
     
@@ -270,19 +273,24 @@ Ext.define('GeoExt.panel.PrintMap', {
      * @private
      */
     afterRender: function() {
-        
-        this.callParent(arguments);
-        this.doComponentLayout();
-        if (!this.ownerCt) {
-            this.bind();
-        } else {
-            this.ownerCt.on({
+        var me = this,
+            listenerSpec = {
                 "afterlayout": {
-                    fn: this.bind,
-                    scope: this,
+                    fn: me.bind,
+                    scope: me,
                     single: true
                 }
-            });
+            };
+
+        me.callParent(arguments);
+        me.doComponentLayout();
+
+        // binding will happen when either we or our container are finished
+        // doing the layout.
+        if (!me.ownerCt) {
+            me.on(listenerSpec);
+        } else {
+            me.ownerCt.on(listenerSpec);
         }
     },
 
@@ -334,7 +342,7 @@ Ext.define('GeoExt.panel.PrintMap', {
             var printBounds = this.printPage.getPrintExtent(this.map);
             this.currentZoom = this.map.getZoomForExtent(printBounds);
             this.map.zoomToExtent(printBounds, false);
-            
+
             delete this._updating;
         }
     },

--- a/tests/data/LayerStore.html
+++ b/tests/data/LayerStore.html
@@ -84,7 +84,6 @@
             t.eq(mapPanel.layers.getCount(),1,"Adding layers to MapPanel's LayerStore does not create duplicate layers");
 
             mapPanel.destroy();
-            map.destroy();
         }
 
         function test_store_to_map(t) {

--- a/tests/data/PrintPage.html
+++ b/tests/data/PrintPage.html
@@ -154,7 +154,14 @@
             });
             
             printPage.fit(mapPanel, {mode: "printer"});
-            t.eq(printPage.center.toString(), center.toString(), "Print page centered correctly.");
+
+            // helper function for lonlat comparisons
+            var toRoundedShortString = function(lonlat, precision){
+                var prec = precision || 3;
+                return (lonlat.lon.toFixed(prec) + ", " + lonlat.lat.toFixed(prec));
+            };
+
+            t.eq(toRoundedShortString(printPage.center), toRoundedShortString(center), "Print page centered correctly.");
             t.eq(printPage.scale.get("value"), 4000000, "Print scale set correctly.");
 
             printPage.fit(mapPanel, {mode: "closest"});


### PR DESCRIPTION
This includes three fixes:
- Round when compairing center coordinates (`panel.PrintMap` test)
- call `panel.PrintMap.bind` in `afterlayout` event
- Do not destroy `map` which is already destroyed when tearing down
  tests (`data.LayerStore` test)

The tests now all pass in Chrome 21 and Firefox 20 (both on a linux box)
and also in Internet Explorer 8 (Windows XP).

![tests-pass-in-ie8](https://f.cloud.github.com/assets/227934/458626/da233988-b3df-11e2-809a-b08710f73ba4.png)

Please review.
