### PR TITLE
Prevent unchecking of radio button in tree

### DIFF
--- a/src/GeoExt/tree/LayerNode.js
+++ b/src/GeoExt/tree/LayerNode.js
@@ -93,7 +93,7 @@ Ext.define('GeoExt.tree.LayerNode', {
             } else if(!checked && layer.isBaseLayer && layer.map && 
                       layer.map.baseLayer && layer.id == layer.map.baseLayer.id) {
                 // Must prevent the unchecking of radio buttons
-                this.target.set('checked', this.target.get('layer').getVisibility());
+                node.set('checked', layer.getVisibility());
             } else {
                 layer.setVisibility(checked);
             }


### PR DESCRIPTION
This fix allow to keep the radio button checked in the tree when the current base layer is clicked in the tree. This recheck the button. From my understanding, it would be really complicated to prevent Ext from unchecking it since it's the first thing the click event does, even before the GeoExt code is triggered. 
