### PR TITLE
No warnings when building docs.

### DIFF
--- a/src/GeoExt/data/LayerStore.js
+++ b/src/GeoExt/data/LayerStore.js
@@ -70,7 +70,7 @@ Ext.define('GeoExt.data.LayerStore', {
      */
 
     /**
-     * @config {Object} Creation parameters
+     * @param {Object} config Creation parameters
      * @private
      */
     constructor: function(config) {

--- a/src/GeoExt/panel/Map.js
+++ b/src/GeoExt/panel/Map.js
@@ -356,8 +356,9 @@ Ext.define('GeoExt.panel.Map', {
      * * `visibility_<XXX>`
      * * `opacity_<XXX>`
      *
-     * The <XXX> suffix is either the title or id of the layer record, it can be
-     * influenced by setting #prettyStateKeys to `true` or `false`.
+     * The &lt;XXX&gt; suffix is either the title or id of the layer record, it
+     * can be influenced by setting #prettyStateKeys to `true` or `false`.
+     *
      * @private
      * @return {Object}
      */

--- a/src/GeoExt/slider/Zoom.js
+++ b/src/GeoExt/slider/Zoom.js
@@ -161,7 +161,7 @@ Ext.define('GeoExt.slider.Zoom', {
     /**
      * Called by a MapPanel if this component is one of the items in the panel.
      * @private
-     * @param {GeoExt.panel.Map}
+     * @param {GeoExt.panel.Map} panel
      */
     removeFromMapPanel: function(panel) {
         var el = this.getEl();
@@ -172,7 +172,7 @@ Ext.define('GeoExt.slider.Zoom', {
 
     /**
      * @private
-     * @param {OpenLayers.Map}
+     * @param {OpenLayers.Map} map
      */
     bind: function(map) {
         this.map = map;

--- a/src/GeoExt/window/Popup.js
+++ b/src/GeoExt/window/Popup.js
@@ -14,7 +14,6 @@
 
 /**
  * @class GeoExt.window.Popup
- * @include GeoExt/panel/Map.js
  *
  * Popups are a specialized Window that supports anchoring
  * to a particular location in a {@link GeoExt.panel.Map MapPanel}.


### PR DESCRIPTION
This adjusts the documentation so that the current JSDuck 5.2.0 doesn't
issue warnings.
