### PR TITLE
Fixing zoom-slider issues

### DIFF
--- a/src/GeoExt/panel/Map.js
+++ b/src/GeoExt/panel/Map.js
@@ -203,7 +203,7 @@ Ext.define('GeoExt.panel.Map', {
             if (typeof this.map.getViewport === "function") {
                 this.items.each(function(cmp) {
                     if (typeof cmp.addToMapPanel === "function") {
-                        cmp.getEl().appendTo(this.map.getViewport());
+                        cmp.getEl().appendTo(this.body);
                     }
                 }, this);
             }

--- a/src/GeoExt/slider/Zoom.js
+++ b/src/GeoExt/slider/Zoom.js
@@ -91,6 +91,45 @@ Ext.define('GeoExt.slider.Zoom', {
     zooming: false,
 
     /**
+     * The number of millisconds to wait (after rendering the slider) before
+     * resizing of the slider happens in case this slider is rendered ad child
+     * of a GeoExt.panel.Map.
+     *
+     * This defaults to 200 milliseconds, which is not really noticeable, and
+     * also rather conservative big.
+     *
+     * @private
+     */
+    resizingDelayMS: 200,
+
+    /**
+     * The height in pixels of the slider thumb. Will be used when we need to
+     * manually resize ourself in case we are added to a mappanel. This will
+     * be the height of the element containing the thumb when we are rendered
+     * horizontally (see #vertical).
+     *
+     * This value shouldn't usually be adjusted, when the default stylesheet of
+     * ExtJS is used.
+     *
+     * @cfg {Number}
+     */
+    thumbHeight: 14,
+
+    /**
+     * The width in pixels of the slider thumb. Will be used when we need to
+     * manually resize ourself in case we are added to a mappanel. This will
+     * be the width of the element containing the thumb when we are rendered
+     * vertically (see #vertical).
+     *
+     * This value shouldn't usually be adjusted, when the default stylesheet of
+     * ExtJS is used.
+     *
+     * @cfg {Number}
+     */
+    thumbWidth: 15,
+
+
+    /**
      * Initialize the component.
      * @private
      */
@@ -138,19 +177,66 @@ Ext.define('GeoExt.slider.Zoom', {
      */
     addToMapPanel: function(panel) {
         this.on({
-            render: function() {
-                var el = this.getEl();
-                el.setStyle({
-                    position: "absolute",
-                    zIndex: panel.map.Z_INDEX_BASE.Control
-                });
+            /**
+             * Once we are rendered and we know that we are a child of a
+             * mappanel, we need to make some adjustments to our DOMs
+             * box dimensions.
+             */
+            afterrender: function(){
+                var me = this,
+                    el = me.getEl(),
+                    dim = {
+                        // depending on our vertical setting, we need to find
+                        // sane values for both width and height.
+                        width: me.vertical ? me.thumbWidth : el.getWidth(),
+                        height: !me.vertical ? me.thumbHeight : el.getHeight(),
+                        top: me.y || 0,
+                        left: me.x || 0
+                    },
+                    resizeFunction,
+                    resizeTask;
+                // Bind handlers that stop the mouse from interacting with the
+                // map below the slider.
                 el.on({
-                    mousedown: this.stopMouseEvents,
-                    click: this.stopMouseEvents
+                    mousedown: me.stopMouseEvents,
+                    click: me.stopMouseEvents
                 });
-            },
-            afterrender: function() {
-                this.bind(panel.map);
+                /**
+                 * This method takes some of the gathered values from above and
+                 * ensures that we have an expected look.
+                 */
+                resizeFunction = function(){
+                    el.setStyle({
+                        top: dim.top,
+                        left: dim.left,
+                        width: dim.width,
+                        position: "absolute",
+                        height: dim.height,
+                        zIndex: panel.map.Z_INDEX_BASE.Control
+                    });
+                    // This is tricky...
+                    if (me.vertical) {
+                        // ...for vertical sliders the height of the surrounding
+                        // element is controlled by the height of the element
+                        // with the 'x-slider-inner'-class
+                        el.down('.x-slider-inner').el.setStyle({
+                            height: dim.height - me.thumbWidth
+                        });
+                    } else {
+                        // ...but for horizontal sliders, it's the form element
+                        // with class 'x-form-item-body' that controls the
+                        // height.
+                        el.down('.x-form-item-body').el.setStyle({
+                            height: me.thumbHeight
+                        });
+                    }
+                };
+                // We delay the execution for a small amount of milliseconds,
+                // so that our changes do take effect.
+                resizeTask = new Ext.util.DelayedTask(resizeFunction);
+                resizeTask.delay(me.resizingDelayMS);
+                // bind the map to the slider
+                me.bind(panel.map);
             },
             scope: this
         });

--- a/tests/panel/Map.html
+++ b/tests/panel/Map.html
@@ -682,9 +682,8 @@
                     ref: "zoomSlider"
                 }
             });
-            t.ok(mapPanel.items.get(0).getEl().dom.parentNode ===
-                    Ext.query(".olMapViewport", mapPanel.map.div)[0],
-                 "Map Panel item has the map's viewport div as parent.");
+            t.ok(mapPanel.items.get(0).getEl().dom.parentNode === mapPanel.body.dom,
+                 "Map Panel item has the panels's body div as parent.");
             mapPanel.destroy();
         }
     </script>


### PR DESCRIPTION
According to https://github.com/geoext/geoext2/issues/184 this provieds fixes for the problems with the jumping thumb when the config-option "aggressive" is enabled and the broken behaviour and appearance of the ZoomSlider inside a MapPanel.
- Jumping thumb: A circle call of of the 2 event-handlers (zoomend and update) should not happen anymore.
- Broken behaviour and appearance: Analog fix to https://github.com/geoext/geoext2/pull/191 of @marcjansen 
