### PR TITLE
when readRecords is passed an array, use callParent instead so that crea...

### DIFF
--- a/src/GeoExt/data/reader/WmsCapabilities.js
+++ b/src/GeoExt/data/reader/WmsCapabilities.js
@@ -131,6 +131,9 @@ Ext.define('GeoExt.data.reader.WmsCapabilities', {
      * @private
      */
     readRecords: function(data) {
+        if (Ext.isArray(data)) {
+            return this.callParent(data);
+        }
         if(typeof data === "string" || data.nodeType) {
             data = this.format.read(data);
         }

--- a/tests/data/reader/WmsCapabilities.html
+++ b/tests/data/reader/WmsCapabilities.html
@@ -154,6 +154,19 @@
             t.eq(transparent, true,
                 "TRANSPARENT param is true if no opacity set");
         }
+
+        function test_createFromLayer(t) {
+            t.plan(1);
+            var layer = new OpenLayers.Layer.WMS('foo', 'http://demo.opengeo.org', {
+                LAYERS: 'states'
+            }, {
+                metadata: {
+                    keywords: ['a', 'b']
+                }
+            });
+            var record = GeoExt.data.WmsCapabilitiesLayerModel.createFromLayer(layer);
+            t.eq(record.get('keywords')[0], 'a', 'keywords read correctly');
+        }
     </script>
   <body>
     <div id="map"></div>


### PR DESCRIPTION
...teFromLayer still works
