### PR TITLE
bug: Map Panel always reattaches the map to the panel

### DIFF
--- a/src/GeoExt/panel/Map.js
+++ b/src/GeoExt/panel/Map.js
@@ -177,6 +177,15 @@ Ext.define('GeoExt.panel.Map', {
     ],
 
     /**
+     * Whether we already rendered an OpenLayers.Map in this panel. Will be
+     * updated in #onResize, after the first rendering happened.
+     *
+     * @property {Boolean} mapRendered
+     * @private
+     */
+    mapRendered: false,
+
+    /**
      * Initializes the map panel. Creates an OpenLayers map if
      * none was provided in the config options passed to the
      * constructor.
@@ -339,9 +348,10 @@ Ext.define('GeoExt.panel.Map', {
      */
     onResize: function() {
         var map = this.map;
-        if(this.body.dom !== map.div) {
+        if(!this.mapRendered && this.body.dom !== map.div) {
             // the map has not been rendered yet
             map.render(this.body.dom);
+            this.mapRendered = true;
 
             this.layers.bind(map);
 


### PR DESCRIPTION
Thanks for GeoExt, we use it in our professional solution.

Since version GeoExt 2, the "GeoExt.panel.Map" object always try to reattach the OpenLayer Map object to the ExtJS panel when the panel is resized.

File: "src\GeoExt\panel\Map.js", Line 335:

``` javascript
    onResize: function() {
        var map = this.map;
        if(this.body.dom !== map.div) {
            // the map has not been rendered yet
            map.render(this.body.dom);
```

The code seems to be a way to apply the first attachment at the appropriate time. Nevertheless this technique prevents us from manually reattach later the Map to somewhere else. This could be needed by a full-screen feature for example.

I'm explaining: for our full-screen feature, the OpenLayer Map is attached to another ExtJs panel which cover the full navigator window. It is attached using "map.render(anotherDiv)". Unfortunately if the navigator window is resized at this time, GeoExt put back the map to the old DIV (see code above).

So it would be more advised if GeoExt attaches the Map to the Panel only once.
