### PR TITLE
Be more cautious when testing for OpenLayers

### DIFF
--- a/src/GeoExt/Version.js
+++ b/src/GeoExt/Version.js
@@ -20,7 +20,7 @@
     if ( Ext.versions.extjs.version ) {
         environment.push('ExtJS: ' + Ext.versions.extjs.version);
     }
-    if ( OpenLayers ) {
+    if ( window.OpenLayers ) {
         environment.push('OpenLayers: ' + OpenLayers.VERSION_NUMBER);
     }
     environment.push('GeoExt: ' + v);


### PR DESCRIPTION
Tests crashed in Chrome without the window notation.
