### PR TITLE
Allow tree legend component rendering to be deferred

### DIFF
--- a/examples/tree/tree-legend-dynamic.html
+++ b/examples/tree/tree-legend-dynamic.html
@@ -1,0 +1,42 @@
+<html>
+    <head>
+        <title>GeoExt Legend Tree dynamic version</title>
+
+        <!-- ExtJS -->
+        <script type="text/javascript" src="http://cdn.sencha.com/ext/gpl/4.2.1/examples/shared/include-ext.js"></script>
+        <script type="text/javascript" src="http://cdn.sencha.com/ext/gpl/4.2.1/examples/shared/options-toolbar.js"></script>
+
+        <!-- Shared -->
+        <link rel="stylesheet" type="text/css" href="http://cdn.sencha.com/ext/gpl/4.2.1/examples/shared/example.css" />
+
+        <!-- You should definitely consider using a custom single-file version of OpenLayers -->
+        <script src="http://openlayers.org/api/2.13.1/OpenLayers.js"></script>
+
+        <script type="text/javascript" src="../loader.js"></script>
+        <script type="text/javascript" src="tree-legend-dynamic.js"></script>
+
+        <style type="text/css">
+        .legend {
+            padding-left: 18px;
+        }
+        .x-tree-elbow, .x-tree-elbow-end {
+            width: 3px !important;
+        }
+        .gx-tree-layer-icon {
+            display: none !important;
+        }
+    </style>
+
+    </head>
+    <body>
+        <div id="desc">
+            <h1>GeoExt Legend Tree</h1>
+
+            <p>This example shows how to add legends to the layer nodes in a
+            tree.</p>
+
+            <p>The js is not minified so it is readable. See
+            <a href="tree-legend.js">tree-legend.js</a>.</p>
+        </div>
+    </body>
+</html>

--- a/examples/tree/tree-legend-dynamic.js
+++ b/examples/tree/tree-legend-dynamic.js
@@ -1,0 +1,145 @@
+Ext.require([
+    'Ext.container.Viewport',
+    'Ext.layout.container.Border',
+    'GeoExt.tree.Panel',
+    'Ext.tree.plugin.TreeViewDragDrop',
+    'GeoExt.panel.Map',
+    'GeoExt.tree.OverlayLayerContainer',
+    'GeoExt.tree.BaseLayerContainer',
+    'GeoExt.data.LayerTreeModel',
+    'GeoExt.tree.View',
+    'GeoExt.container.WmsLegend',
+    'GeoExt.tree.Column',
+    // We need to require this class, even though it is used by Ext.EventObjectImpl
+    // see: http://www.sencha.com/forum/showthread.php?262124-Missed-(-)-dependency-reference-to-a-Ext.util.Point-in-Ext.EventObjectImpl
+    'Ext.util.Point'
+]);
+
+Ext.application({
+    name: 'Tree Legend',
+    launch: function() {
+        var mapPanel = new GeoExt.MapPanel({
+            region: "center",
+            center: [146.1569825, -41.6109735],
+            zoom: 6,
+            layers: [
+                new OpenLayers.Layer.WMS("Tasmania State Boundaries",
+                    "http://demo.opengeo.org/geoserver/wms", {
+                        layers: "topp:tasmania_state_boundaries"
+                    }, {
+                        buffer: 0,
+                        // exclude this layer from layer container nodes
+                        displayInLayerSwitcher: false
+                   }),
+                new OpenLayers.Layer.WMS("Water",
+                    "http://demo.opengeo.org/geoserver/wms", {
+                        layers: "topp:tasmania_water_bodies",
+                        transparent: true,
+                        format: "image/gif"
+                    }, {
+                        buffer: 0
+                    }),
+                new OpenLayers.Layer.WMS("Cities",
+                    "http://demo.opengeo.org/geoserver/wms", {
+                        layers: "topp:tasmania_cities",
+                        transparent: true,
+                        format: "image/gif"
+                    }, {
+                        buffer: 0
+                    }),
+                new OpenLayers.Layer.WMS("Tasmania Roads",
+                    "http://demo.opengeo.org/geoserver/wms", {
+                        layers: "topp:tasmania_roads",
+                        transparent: true,
+                        format: "image/gif"
+                    }, {
+                        buffer: 0
+                    })
+            ]
+        });
+
+        var store = Ext.create('Ext.data.TreeStore', {
+            model: 'GeoExt.data.LayerTreeModel',
+            root: {
+                plugins: [{
+                    ptype: "gx_layercontainer",
+                    loader: {
+                        createNode: function(attr) {
+                            // add a WMS legend to each node created
+                            attr.component = {
+                                xtype: "gx_wmslegend",
+                                layerRecord: mapPanel.layers.getByLayer(attr.layer),
+                                showTitle: false,
+                                hidden: true,
+                                deferRender: true,
+                                // custom class for css positioning
+                                // see tree-legend.html
+                                cls: "legend"
+                            };
+                            return GeoExt.tree.LayerLoader.prototype.createNode.call(this, attr);
+                        }
+                    }
+                }]
+            }
+        });
+
+        
+
+        var tree = new GeoExt.tree.Panel({
+            title: "Layers",
+            width: 250,
+            autoScroll: true,
+            viewConfig: {
+                plugins: [{
+                    ptype: 'treeviewdragdrop',
+                    appendOnly: false
+                }]
+            },
+            store: store,
+            rootVisible: false,
+            lines: false,
+            listeners:{
+                cellclick: function(tree, td, cellIndex, record) {
+                  var node = record;
+                  var legend = record.gx_treecomponents.gx_wmslegend;
+                  if (legend.isHidden()) {
+                    if (!legend.rendered) {
+                      legend.render(node.el);
+                    }
+                    // NOTE: will not recalculate height of tree panel
+                    legend.show();
+                  } else {
+                    legend.hide();
+                  }
+                  
+                  // NOTE: this will recalculate height of tree panel
+                  /*tree.getTreeStore().getRootNode().appendChild({
+                    text: "Test"
+                  });*/
+                },
+                scope: this
+            }
+        });
+        
+        var east = Ext.create('Ext.Panel', {
+            region: "east",
+            items: [tree, { title: "Other stuff", width: 250, html: "Test" }]
+        });
+
+        new Ext.Viewport({
+            layout: "fit",
+            hideBorders: true,
+            items: {
+                layout: "border",
+                items: [
+                    mapPanel, east, {
+                        contentEl: desc,
+                        region: "west",
+                        width: 250,
+                        bodyStyle: {padding: "5px"}
+                    }
+                ]
+            }
+        });
+    }
+});

--- a/src/GeoExt/LegendImage.js
+++ b/src/GeoExt/LegendImage.js
@@ -53,6 +53,7 @@ Ext.define('GeoExt.LegendImage', {
 
     initComponent: function(){
         var me = this;
+        me.addEvents('legendimageloaded');
         me.callParent(arguments);
         if(this.defaultImgSrc === null) {
             this.defaultImgSrc = Ext.BLANK_IMAGE_URL;
@@ -130,6 +131,7 @@ Ext.define('GeoExt.LegendImage', {
         if (!OpenLayers.Util.isEquivalentUrl(el.dom.src, this.defaultImgSrc)) {
             el.removeCls(this.noImgCls);
         }
+        this.fireEvent('legendimageloaded', this);
     }
 
 });

--- a/src/GeoExt/container/UrlLegend.js
+++ b/src/GeoExt/container/UrlLegend.js
@@ -86,7 +86,7 @@ Ext.define('GeoExt.container.UrlLegend', {
         me.addEvents('legendimageloaded');
         me.callParent(arguments);
         this.add(Ext.create('GeoExt.LegendImage', {
-            url: this.layerRecord.get("legendURL"),,
+            url: this.layerRecord.get("legendURL"),
             listeners: {
                 'legendimageloaded': function() {
                     this.fireEvent('legendimageloaded', this);

--- a/src/GeoExt/container/UrlLegend.js
+++ b/src/GeoExt/container/UrlLegend.js
@@ -83,9 +83,16 @@ Ext.define('GeoExt.container.UrlLegend', {
      */
     initComponent: function(){
         var me = this;
+        me.addEvents('legendimageloaded');
         me.callParent(arguments);
         this.add(Ext.create('GeoExt.LegendImage', {
-            url: this.layerRecord.get("legendURL")
+            url: this.layerRecord.get("legendURL"),,
+            listeners: {
+                'legendimageloaded': function() {
+                    this.fireEvent('legendimageloaded', this);
+                },
+                scope: this
+            }
         }));
     },
 

--- a/src/GeoExt/container/WmsLegend.js
+++ b/src/GeoExt/container/WmsLegend.js
@@ -86,6 +86,7 @@ Ext.define('GeoExt.container.WmsLegend', {
 
     initComponent: function(){
         var me = this;
+        me.addEvents('legendimageloaded');
         me.callParent();
         var layer = me.layerRecord.getLayer();
         me._noMap = !layer.map;
@@ -224,7 +225,13 @@ Ext.define('GeoExt.container.WmsLegend', {
                 this.add({
                     xtype: "gx_legendimage",
                     url: this.getLegendUrl(layerName, layerNames),
-                    itemId: layerName
+                    itemId: layerName,
+                    listeners: {
+                        'legendimageloaded': function() {
+                            this.fireEvent('legendimageloaded', this);
+                        },
+                        scope: this
+                    }
                 });
             }
         }

--- a/src/GeoExt/data/LayerTreeModel.js
+++ b/src/GeoExt/data/LayerTreeModel.js
@@ -35,14 +35,20 @@
  *         component: {
  *             xtype: "gx_wmslegend",
  *             layerRecord: myLayerRecord,
- *             showTitle: false
+ *             showTitle: false,
+ *             deferRender: false
  *         }
  *     }
  *
  * The above creates a node with a GeoExt.tree.LayerNode plugin, and connects
  * it to a layer record that was previously assigned to the myLayerRecord
  * variable. The node will be rendered with a GeoExt.container.WmsLegend,
- * configured with the same layer.
+ * configured with the same layer. The option deferRender is set to its default
+ * value false which means the component will be rendered as soon as the layer
+ * node is created. If deferRender is set to true the component will not be
+ * rendered automatically and must instead be rendered manually, preferably
+ * to the node element which is available on layer nodes as a property named
+ * el.
  *
  * @class GeoExt.data.LayerTreeModel
  */

--- a/src/GeoExt/tree/View.js
+++ b/src/GeoExt/tree/View.js
@@ -113,6 +113,10 @@ Ext.define('GeoExt.tree.View', {
             if (!component.deferRender) {
                 cmpObj.render(el);
             }
+            
+            cmpObj.on('legendimageloaded', function() {
+              this.updateLayout();
+            }, this);
 
             el.removeCls('gx-tree-component-off');
         }


### PR DESCRIPTION
Also adds a reference to el on node which can be used to render the component later.

Main purpose of this is to be able to initially hide legend and only loading them on demand.