### PR TITLE
Modularize and enhance the headless test script.

### DIFF
--- a/tests/headless/modules/strUtil.js
+++ b/tests/headless/modules/strUtil.js
@@ -1,0 +1,69 @@
+/**
+ * Pads a string with spaces on the specified side(s) up to the given length.
+ * 
+ * @param {String} s The string we will be padding.
+ * @param {Number} len The length the returned padded string shall have.
+ * @param {String} side The side where the padding will be added. Can be either
+ *     `left`, `right` or `both`.
+ * @returns {String} The padded string or the given string if an unrecognized
+ *     side was passed.
+ */
+function pad(s, len, side) {
+    var str = "" + s,
+        length = parseInt(len, 10),
+        spaces = (new Array(length + 1)).join(" ");
+    switch (side.toLowerCase()) {
+        case 'left':
+            return (spaces + str).substr(-1*length);
+            break;
+        case 'right':
+            return (str + spaces).substring(0, length);
+            break;
+        case 'both':
+            var diff = length - str.length,
+                leftLen = Math.floor(diff/2),
+                rightLen = diff - leftLen;
+            return pad('', leftLen, 'left') + str + pad('', rightLen, 'right');
+    }
+    // fallback for illegal side; returned the passed string directly
+    return str;
+}
+
+/**
+ * Pads a string with spaces on the left side up to the given length.
+ * 
+ * @param {String} s The string we will be padding.
+ * @param {Number} len The length the returned padded string shall have.
+ * @returns {String} The padded string.
+ */
+function padLeft(s, len) {
+    return pad(s, len, 'left');
+}
+
+/**
+ * Pads a string with spaces on the right side up to the given length.
+ * 
+ * @param {String} s The string we will be padding.
+ * @param {Number} len The length the returned padded string shall have.
+ * @returns {String} The padded string.
+ */
+function padRight(s, len) {
+    return pad(s, len, 'right');
+}
+
+/**
+ * Pads a string with spaces on both sides up to the given length.
+ * 
+ * @param {String} s The string we will be padding.
+ * @param {Number} len The length the returned padded string shall have.
+ * @returns {String} The padded string.
+ */
+function padBoth(s, len) {
+    return pad(s, len, 'both');
+}
+
+
+exports.pad = pad;
+exports.padLeft = padLeft;
+exports.padRight = padRight;
+exports.padBoth = padBoth;

--- a/tests/headless/modules/tawWrapper.js
+++ b/tests/headless/modules/tawWrapper.js
@@ -1,0 +1,185 @@
+/**
+ * When executed in the context of the 'list-tests.html' file, this method will
+ * return an array of all the test files referenced in the list.
+ *
+ * This method assumes a list-tests.html layout of:
+ *
+ *     <ul id="testlist">
+ *         <li>Action.html</li>
+ *         <!-- ... -->
+ *     </ul>
+ *
+ * @returns {String[]} The names of the referenced test files.
+ */
+function getTestFiles() {
+    var links = document.querySelectorAll('li');
+    return Array.prototype.map.call(links, function(e) {
+        return e.innerHTML;
+    });
+}
+
+/**
+ * When executed in the context of a test file, this method will return an array
+ * of the names of all globally defined functions with their names starting with
+ * 'test_', these are the single functions that Test.Anotherway would be
+ * executing.
+ *
+ * @returns {String[]}
+ */
+function getTestFunctions() {
+    var funcs = [],
+        isFunc = function (obj) {
+            return Object.prototype.toString.call(obj) === '[object Function]';
+        };
+    for ( var key in window ) {
+        if ( /test_/.test(key) && isFunc(window[key]) ) {
+            funcs.push(key);
+        }
+    }
+    return funcs;
+}
+
+/**
+ * Runs the function with the given name in the context of the file it was
+ * defined in. Expects to be called in that context. Will return an array of
+ * objects with details about the tests in the functions: 
+ * 
+ *   * The first object has one member `info` with the passed over function name
+ *     and the name of the file.
+ *   * All other objects returned are the results of a single test. All contain
+ *     a member `msg` with a printable message, and then either the key `pass`
+ *     or the key `skip`:
+ *     * `pass` will be there if we could run the function and could gather a
+ *       test result. If `pass` is `true` the test passed, if the test failed,
+ *       `pass` will be `false`.
+ *     * `skip` will be there if we detected a method call that we currently
+ *       cannot emulate. This will be the case for `t.delay_call` and
+ *       `t.wait_result`.
+ * 
+ * @param {String} name The name of a test function (usually gathered by
+ *     #getTestFunctions). 
+ * @param {String} filename The filename that the function is defined in. Mainly
+ *     there to have a better `info` member.
+ * @returns {Object[]} An array with a meta-object (for informational purposes)
+ *     and one object with the test results for every executed or skipped test.
+ */
+function runOneTestFunc(name, filename) {
+    var results = [
+            {info: filename + " " + name + "(t):"}
+        ],
+        toString = Object.prototype.toString,
+        isArr = function(o) {
+            return toString.call(o) === '[object Array]';
+        },
+        isObj = function(o) {
+            return toString.call(o) === '[object Object]';
+        },
+        eqFunc = function(a, b) {
+            if (a === null && b === null) {
+                return true;
+            }
+            if (toString.call(a) !== toString.call(b)) {
+                return false;
+            }
+            if (isArr(a)) {
+                if (a.length !== b.length) {
+                    return false;
+                }
+                for (var i = 0; i < a.length; i++) {
+                    if (!eqFunc(a[i], b[i])) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            if (isObj(a)) {
+                for (var k in a) {
+                    if (!eqFunc(a[k], b[k])) {
+                        return false;
+                    }
+                }
+                // could be optimized
+                for (var kk in b) {
+                    if (!eqFunc(a[kk], b[kk])) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return a === b;
+        },
+        debugInfo = function(mockMethod, testName, filename, other) {
+            return [
+                " [",
+                mockMethod + ", ",
+                testName + "(t), ",
+                filename,
+                (other ? other : ''),
+                "]"
+            ].join("");
+        },
+        mock = {
+            plan: function() {},
+            ok: function(cond, msg) {
+                if (!cond) {
+                    results.push({
+                        pass: false,
+                        msg: msg + debugInfo("t.ok", name, filename)
+                    })
+                } else {
+                    results.push({pass: true, msg: msg});
+                }
+            },
+            eq: function(got, exp, msg) {
+                //if (got !== exp) {
+                if(!eqFunc(got, exp)) {
+                    results.push({
+                        pass: false,
+                        msg: msg +
+                            debugInfo(
+                                "t.eq", name, filename,
+                                "exp: " + exp + ", got: " + got
+                            )
+                    });
+                } else {
+                    results.push({pass: true, msg: msg});
+                }
+            },
+            fail: function(msg) {
+                results.push({
+                    pass: false,
+                    msg: msg + debugInfo("t.fail", name, filename)
+                });
+            },
+            delay_call : function(s, fn) {
+                // TODO
+                results.push({
+                    skip: true,
+                    msg: "not supported" + debugInfo("t.delay_call", name, filename)
+                });
+            },
+            wait_result: function(s) {
+                // TODO
+                results.push({
+                    skip: true,
+                    msg: "not supported" + debugInfo("t.wait_result", name, filename)
+                });
+            }
+        };
+    if (window[name]) {
+        try {
+            window[name].call(this, mock);
+        } catch (e) {
+            results = [{
+                pass: false,
+                msg: "Caught exception: " + debugInfo("calling method", name, filename, e)
+            }];
+        }
+    }
+    return results;
+}
+
+
+exports.getTestFiles = getTestFiles;
+exports.getTestFunctions = getTestFunctions;
+exports.runOneTestFunc = runOneTestFunc;

--- a/tests/headless/run-testsuite.js
+++ b/tests/headless/run-testsuite.js
@@ -1,173 +1,51 @@
-function getLinks() {
-    var links = document.querySelectorAll('li');
-    return Array.prototype.map.call(links, function(e) {
-        return e.innerHTML;
-    });
-}
+var fs = require('fs'),
+    system = require('system'),
+    dash = fs.separator,
+    currentFile = system.args[4], // the full path to run-testsuite.js
+    curFileParts = fs.absolute(currentFile).split(dash);
 
-function getTestFunctions() {
-    var funcs = [],
-        isFunc = function (obj) {
-            return Object.prototype.toString.call(obj) === '[object Function]';
-        };
-    for ( var key in window ) {
-        if ( /test_/.test(key) && isFunc(window[key]) ) {
-            funcs.push(key);
-        }
-    }
-    return funcs;
-}
+// remove filename 'run-testsuite.js'
+curFileParts.pop();
+// remove containing folder 'headless' 
+curFileParts.pop();
 
-function runOneTestFunc(name, filename) {
-    var results = [
-            {info: filename + " " + name + "(t):"}
-        ],
-        toString = Object.prototype.toString,
-        isArr = function(o) {
-            return toString.call(o) === '[object Array]';
-        },
-        isObj = function(o) {
-            return toString.call(o) === '[object Object]';
-        },
-        eqFunc = function(a, b) {
-            if (a === null && b === null) {
-                return true;
-            }
-            if (toString.call(a) !== toString.call(b)) {
-                return false;
-            }
-            if (isArr(a)) {
-                if (a.length !== b.length) {
-                    return false;
-                }
-                for (var i = 0; i < a.length; i++) {
-                    if (!eqFunc(a[i], b[i])) {
-                        return false;
-                    }
-                }
-                return true;
-            }
-            if (isObj(a)) {
-                for (var k in a) {
-                    if (!eqFunc(a[k], b[k])) {
-                        return false;
-                    }
-                }
-                // could be optimized
-                for (var kk in b) {
-                    if (!eqFunc(a[kk], b[kk])) {
-                        return false;
-                    }
-                }
-                return true;
-            }
-            return a === b;
-        },
-        debugInfo = function(mockMethod, testName, filename, other) {
-            return [
-                " [",
-                mockMethod + ", ",
-                testName + "(t), ",
-                filename,
-                (other ? other : ''),
-                "]"
-            ].join("");
-        },
-        mock = {
-            plan: function() {},
-            ok: function(cond, msg) {
-                if (!cond) {
-                    results.push({
-                        pass: false,
-                        msg: msg + debugInfo("t.ok", name, filename)
-                    })
-                } else {
-                    results.push({pass: true, msg: msg});
-                }
-            },
-            eq: function(got, exp, msg) {
-                //if (got !== exp) {
-                if(!eqFunc(got, exp)) {
-                    results.push({
-                        pass: false,
-                        msg: msg +
-                            debugInfo(
-                                "t.eq", name, filename,
-                                "exp: " + exp + ", got: " + got
-                            )
-                    });
-                } else {
-                    results.push({pass: true, msg: msg});
-                }
-            },
-            fail: function(msg) {
-                results.push({
-                    pass: false,
-                    msg: msg + debugInfo("t.fail", name, filename)
-                });
-            },
-            delay_call : function(s, fn) {
-                // TODO
-                results.push({
-                    skip: true,
-                    msg: "not supported" + debugInfo("t.delay_call", name, filename)
-                });
-            },
-            wait_result: function(s) {
-                // TODO
-                results.push({
-                    skip: true,
-                    msg: "not supported" + debugInfo("t.wait_result", name, filename)
-                });
-            }
-        };
-    if (window[name]) {
-        try {
-            window[name].call(this, mock);
-        } catch (e) {
-            results = [{
-                pass: false,
-                msg: "Caught exception: " + debugInfo("calling method", name, filename, e)
-            }];
-        }
-    }
-    return results;
-}
+var basePath = curFileParts.join(dash) + dash;
+var modulePath = basePath  + 'headless' + dash + 'modules' + dash;
 
-function leftPad(s, len) {
-    var str = "" + s,
-        length = parseInt(len, 10),
-        spaces = (new Array(length)).join(" ");
-    return (spaces + str).substr(-1*length);
-}
+// the html file with the links
+var tawListOfTestsFile = basePath + 'list-tests.html';
 
-function rightPad(s, len) {
-    var str = "" + s,
-        length = parseInt(len, 10),
-        spaces = (new Array(length)).join(" ");
-    return (str + spaces).substring(0, length);
-}
+var strUtil = require(modulePath + 'strUtil'),
+    padLeft = strUtil.padLeft,
+    padRight = strUtil.padRight;
 
-var baseUrl = 'http://localhost:1234/tests/';
-baseUrl= './tests/'
-var linksUrl = baseUrl + 'list-tests.html';
+var tawWrapper = require(modulePath + 'tawWrapper'),
+    getTestFiles = tawWrapper.getTestFiles,
+    getTestFunctions = tawWrapper.getTestFunctions,
+    runOneTestFunc = tawWrapper.runOneTestFunc;
+
+
+// the variables we'll fill during the first phase and iterate over in the
+// second phase
 var links = [];
 var funcCnt = 0;
 var results = [];
 var total = 0;
 
+
+
 // Open the TAW-list of urls
-casper.start(linksUrl);
+casper.start(tawListOfTestsFile);
 
 casper.then(function() {
     // get all testfiles
-    links = this.evaluate(getLinks);
+    links = this.evaluate(getTestFiles);
 });
 
 casper.then(function() {
     links.forEach(function(link) {
         var funcs;
-        casper.thenOpen(baseUrl + link, function(){
+        casper.thenOpen(basePath + link, function(){
             funcs = this.evaluate(getTestFunctions);
         });
         casper.then(function() {
@@ -178,7 +56,7 @@ casper.then(function() {
                 total += oneFuncLen;
                 results.push(oneFuncResults);
                 this.echo(
-                    rightPad(link, 30) + " " + oneFuncLen +
+                    padRight(link, 30) + " " + oneFuncLen +
                     " test" + (oneFuncLen !== 1 ? 's': '') +
                     " in "  + func + "(t)"
                 );
@@ -197,7 +75,7 @@ casper.then(function(){
                 if (result.info) {
                     test.info(result.info);
                 } else {
-                    var message = leftPad((++cnt), 4) + ") " + result.msg;
+                    var message = padLeft((++cnt), 4) + ") " + result.msg;
                     if (result.skip) {
                         test.skip(1, message)
                     } else {


### PR DESCRIPTION
This refactors the test-script `run-testsuite.js`, so it isn't one big file,
but uses two newly created modules: `strUtil` and `tawWrapper`.
- `strUtil` exports methods for padding strings.
- `tawWrapper` exports methods for finding test-files, plus finding and
  executing Test.Anotherway functions.

Also included in this commit is a more robust way of detecting the base path
of the testsuite. This script should now be callable from everywhere, not only
from the root of the repository.

Please review.
