### PR TITLE
Fix several issues in the `panel.PrintMap`-class

### DIFF
--- a/examples/printpreview/print-preview.js
+++ b/examples/printpreview/print-preview.js
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2008-2013 The Open Source Geospatial Foundation
- * 
+ *
  * Published under the BSD license.
  * See https://github.com/geoext/geoext2/blob/master/license.txt for the full
  * text of the license.
@@ -18,18 +18,18 @@ var mapPanel, printDialog, printProvider;
 
 Ext.application({
     name: 'PrintPreviewGeoExt2',
-    
+
     launch: function() {
 
-	    // The PrintProvider that connects us to the print service
-	    printProvider = Ext.create('GeoExt.data.MapfishPrintProvider', {
-	        method: "GET", // "POST" recommended for production use
-	        capabilities: printCapabilities, // provide url instead for lazy loading
-	        customParams: {
-	            mapTitle: "GeoExt Printing Demo",
-	            comment: "This demo shows how to use GeoExt.PrintMapPanel"
-	        }
-	    });
+        // The PrintProvider that connects us to the print service
+        printProvider = Ext.create('GeoExt.data.MapfishPrintProvider', {
+            method: "GET", // "POST" recommended for production use
+            capabilities: printCapabilities, // provide url instead for lazy loading
+            customParams: {
+                mapTitle: "GeoExt Printing Demo",
+                comment: "This demo shows how to use GeoExt.PrintMapPanel"
+            }
+        });
 
     var style = {
             strokeColor: '#000000',
@@ -62,54 +62,54 @@ Ext.application({
         // Add the cities to the layer
         vecLayer.addFeatures([burnie, devonport, hobart]);
 
-	    // A MapPanel with a "Print..." button
-	    mapPanel = Ext.create('GeoExt.panel.Map', {
-	        renderTo: "content",
-	        width: 500,
-	        height: 350,
-	        map: {
-	            maxExtent: new OpenLayers.Bounds(
-	                143.835, -43.648,
-	                148.479, -39.574
-	            ),
-	            maxResolution: 0.018140625,
-	            projection: "EPSG:4326",
-	            units: 'degrees'
-	        },
-	        layers: [
-	            new OpenLayers.Layer.WMS(
-	                "Tasmania State Boundaries",
-	                "http://demo.opengeo.org/geoserver/wms",
-	                { layers: "topp:tasmania_state_boundaries" }
-	            ),
-	            vecLayer
-	        ],
-	        center: [146.56, -41.56],
-	        zoom: 0,
-	        bbar: [{
-	            text: "Print...",
-	            handler: function(){
-	                // A window with the PrintMapPanel, which we can use to adjust
-	                // the print extent before creating the pdf.
-	                printDialog = Ext.create('Ext.Window', {
-	                    title: "Print Preview",
-	                    layout: "fit",
-	                    border: false,
-	                    width: 350,
-	                    autoHeight: true,
-	                    items: [{
-	                        xtype: "gx_printmappanel",
-	                        sourceMap: mapPanel,
-	                        printProvider: printProvider
-	                    }],
-	                    bbar: [{
-	                        text: "Create PDF",
-	                        handler: function(){ printDialog.items.get(0).print(); }
-	                    }]
-	                });
-	                printDialog.show();
-	            }
-	        }]
-	    });
+        // A MapPanel with a "Print..." button
+        mapPanel = Ext.create('GeoExt.panel.Map', {
+            renderTo: "content",
+            width: 500,
+            height: 350,
+            map: {
+                maxExtent: new OpenLayers.Bounds(
+                    143.835, -43.648,
+                    148.479, -39.574
+                ),
+                maxResolution: 0.018140625,
+                projection: "EPSG:4326",
+                units: 'degrees'
+            },
+            layers: [
+                new OpenLayers.Layer.WMS(
+                    "Tasmania State Boundaries",
+                    "http://demo.opengeo.org/geoserver/wms",
+                    { layers: "topp:tasmania_state_boundaries" }
+                ),
+                vecLayer
+            ],
+            center: [146.56, -41.56],
+            zoom: 0,
+            bbar: [{
+                text: "Print...",
+                handler: function(){
+                    // A window with the PrintMapPanel, which we can use to adjust
+                    // the print extent before creating the pdf.
+                    printDialog = Ext.create('Ext.Window', {
+                        title: "Print Preview",
+                        layout: "fit",
+                        border: false,
+                        width: 350,
+                        autoHeight: true,
+                        items: [{
+                            xtype: "gx_printmappanel",
+                            sourceMap: mapPanel,
+                            printProvider: printProvider
+                        }],
+                        bbar: [{
+                            text: "Create PDF",
+                            handler: function(){ printDialog.items.get(0).print(); }
+                        }]
+                    });
+                    printDialog.show();
+                }
+            }]
+        });
     }
 });

--- a/src/GeoExt/panel/PrintMap.js
+++ b/src/GeoExt/panel/PrintMap.js
@@ -191,7 +191,6 @@ Ext.define('GeoExt.panel.PrintMap', {
         if (!this.map) {
             this.map = {};
         }
-
         Ext.applyIf(this.map, {
             projection: this.sourceMap.getProjection(),
             maxExtent: this.sourceMap.getMaxExtent(),
@@ -201,7 +200,6 @@ Ext.define('GeoExt.panel.PrintMap', {
             allOverlays: true,
             fallThrough: true
         });
-
         if(!(this.printProvider instanceof GeoExt.data.MapfishPrintProvider)) {
             this.printProvider = Ext.create('GeoExt.data.MapfishPrintProvider',
                 this.printProvider);
@@ -252,7 +250,6 @@ Ext.define('GeoExt.panel.PrintMap', {
      * @private
      */
     bind: function() {
-
         // we have to call syncSize here because of changed
         // rendering order in ExtJS4
         this.syncSize();


### PR DESCRIPTION
This PR fixes several issues with the `panel.PrintMap`-class:
- When cloning the layers of the `sourceMap`, vector layers previously got special handling and would be recreated instead of being cloned; effectively this lead to loosing configured properties, e.g. a `StyleMap`. Vectors can simply be cloned, as `OpenLayers` handles the cloning of contained features for us.
- The `PrintMap` throws an error if it is being created with an `OpenLayers.TileManager`
- The examnple now also has a vector layer that shows that we can now correctly clone/print vector layers with a style map.
- dangling whitespace was removed and tabs were replaced with spaces

Fixes #217.
