### PR TITLE
fixing issue #205 (Zoomslider can become out-of sync with actual zoom)

### DIFF
--- a/examples/zoomslider/zoomslider.js
+++ b/examples/zoomslider/zoomslider.js
@@ -23,7 +23,9 @@ Ext.onReady(function() {
         height: 300,
         width: 400,
         map: {
-            controls: [new OpenLayers.Control.Navigation()]
+            controls: [new OpenLayers.Control.Navigation()],
+            maxResolution: 0.703125,
+            zoomMethod: null
         },
         layers: [new OpenLayers.Layer.WMS(
             "Global Imagery",


### PR DESCRIPTION
fixing issue by setting zoomMethod to null.
Restricting the maps resolution to match layers requirements
