### PR TITLE
Only render components when node is checked.

### DIFF
--- a/src/GeoExt/tree/View.js
+++ b/src/GeoExt/tree/View.js
@@ -88,6 +88,7 @@ Ext.define('GeoExt.tree.View', {
      */
     createChild: function(el, node) {
         var component = node.get('component'),
+            isChecked = node.get('checked'),
             cmpObj;
 
         if(component) {
@@ -108,7 +109,9 @@ Ext.define('GeoExt.tree.View', {
             }
             node.gx_treecomponents[cmpObj.xtype] = cmpObj;
 
-            cmpObj.render(el);
+            if (isChecked !== false) {
+                cmpObj.render(el);
+            }
 
             el.removeCls('gx-tree-component-off');
         }


### PR DESCRIPTION
When we render components of the `GeoExt.tree.View`, we currently do this unconditionally. This leads to interesting side effects:

Have a look at [the LegendTree-example](http://geoext.github.io/geoext2/examples/tree/tree-legend.html). First all layers are visible in the map, have their checkbox in the tree checked and show the legend for every layer. When you turn one layer off, everything is still fine (legend is hidden, the layer isn't vsible on the map). When you now drag that particular layer to another place in the tree, the legendimage is rendered unconditionally, so that the layer isn't visible on the map, the checkbox is unchecked _but_ the legendimage is there.

This PR proposes to only actually render any components, when the corresponding node is checked.

The issue described above is fixed by the proposed change.

All tests continue to pass for me locally in Chrome 33, Firefox 27 (both Linux) and Internet Explorer 9 (Win7).

Please comment and review.
