### PR TITLE
Avoiding cut-off of headings with fixed launcher on Ubuntu

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
     </div>
 
     <div class="row">
-      <h1 class="topic">About GeoExt</h1>
+      <h1 class="span12 topic">About GeoExt</h1>
       <div class="span8">
         <p>
           Since version 2, GeoExt is based upon the newest Ext JS 4.
@@ -96,7 +96,7 @@
     </div>
 
     <div class="row">
-      <h1 class="topic">Download</h1>
+      <h1 class="span12 topic">Download</h1>
       <div class="span12">
         <p>
         The current released version of GeoExt is 2.0.0.
@@ -109,7 +109,7 @@
     </div>
 
     <div class="row">
-      <h1 class="topic">Examples</h1>
+      <h1 class="span12 topic">Examples</h1>
     </div>
     <div class="examples_container">
       <div class="row">
@@ -251,7 +251,7 @@
   </div>
 
   <div class="row">
-    <h1 class="topic">What about GeoExt 1.x?</h1>
+    <h1 class="span12 topic">What about GeoExt 1.x?</h1>
     <div class="span12">
       <p>
         Of course you can still use <a href="http://geoext.org">GeoExt 1.x</a>.
@@ -270,7 +270,7 @@
   </div>
 
   <div class="row">
-    <h1 class="topic">Now: Get involved!</h1>
+    <h1 class="span12 topic">Now: Get involved!</h1>
   </div>
 
   <div class="row">


### PR DESCRIPTION
Hi,

today I've visited the GeoExt2 website and with a fixed launcher on Ubuntu the h1 headings are cut off. 
![geoextsitewithoutspan12](https://f.cloud.github.com/assets/2471172/2399657/0e6837e4-aa01-11e3-8490-684297e6cdbe.png)

For that reason I've added Bootstraps "span12" class to the headings.
![geoextsitewithspan12](https://f.cloud.github.com/assets/2471172/2399699/ad3b0a36-aa01-11e3-8229-cb562a424c25.png)

Hope you like it!

Cheers,
Matthias
