### PR TITLE
checkedGroup only seems to work with baseLayers

### DIFF
--- a/src/GeoExt/tree/LayerNode.js
+++ b/src/GeoExt/tree/LayerNode.js
@@ -57,6 +57,7 @@ Ext.define('GeoExt.tree.LayerNode', {
             "visibilitychanged": this.onLayerVisibilityChanged,
             scope: this
         });
+        this.enforceOneVisible();
     },
 
     /**
@@ -108,6 +109,33 @@ Ext.define('GeoExt.tree.LayerNode', {
                 layer.setVisibility(checked);
             }
             delete node._visibilityChanging;
+        }
+        this.enforceOneVisible();
+    },
+
+    enforceOneVisible: function() {
+        var attributes = this.target.data;
+        var group = attributes.checkedGroup;
+        // If we are in the baselayer group, the map will take care of
+        // enforcing visibility.
+        if(group && group !== "gx_baselayer") {
+            var layer = this.target.get('layer');
+            var checkedNodes = this.target.getOwnerTree().getChecked();
+            var checkedCount = 0;
+            // enforce "not more than one visible"
+            Ext.each(checkedNodes, function(n){
+                var l = n.data.layer;
+                if(!n.data.hidden && n.data.checkedGroup === group) {
+                    checkedCount++;
+                    if(l != layer && attributes.checked) {
+                        l.setVisibility(false);
+                    }
+                }
+            });
+            // enforce "at least one visible"
+            if(checkedCount === 0 && attributes.checked == false) {
+                layer.setVisibility(true);
+            }
         }
     }
 


### PR DESCRIPTION
In GeoExt 1 we had the enforceOnce function.

When using a checkedGroup in combination with allOverlays (the default in GeoExt), you can get more than one item in the group checked currently.

Also the checkbox css does not work well (look nice) with other themes such as Neptune.
