### PR TITLE
Add an optional keepRaw property

### DIFF
--- a/src/GeoExt/data/reader/WmsCapabilities.js
+++ b/src/GeoExt/data/reader/WmsCapabilities.js
@@ -44,6 +44,12 @@ Ext.define('GeoExt.data.reader.WmsCapabilities', {
     },
 
     /**
+     * Should we keep the raw parsed result? Default is false.
+     * @cfg {Boolean}
+     */
+    keepRaw: false,
+
+    /**
      * CSS class name for the attribution DOM elements.
      * Element class names append "-link", "-image", and "-title" as
      * appropriate.  Default is "gx-attribution".
@@ -119,6 +125,15 @@ Ext.define('GeoExt.data.reader.WmsCapabilities', {
     },
 
     /**
+     * @private
+     */
+    destroyReader: function() {
+        var me = this;
+        delete me.raw;
+        this.callParent();
+    },
+
+    /**
      * Create a data block containing Ext.data.Records from an XML document.
      *
      * @param {DOMElement/String/Object} data A document element or XHR
@@ -139,6 +154,9 @@ Ext.define('GeoExt.data.reader.WmsCapabilities', {
         }
         if (!!data.error) {
             Ext.Error.raise({msg: "Error parsing WMS GetCapabilities", arg: data.error});
+        }
+        if (this.keepRaw) {
+            this.raw = data;
         }
         var version = data.version;
         var capability = data.capability || {};

--- a/src/GeoExt/data/reader/WmsDescribeLayer.js
+++ b/src/GeoExt/data/reader/WmsDescribeLayer.js
@@ -24,6 +24,11 @@ Ext.define('GeoExt.data.reader.WmsDescribeLayer', {
         'GeoExt.Version'
     ],
     /**
+     * Should we keep the raw parsed result? Default is false.
+     * @cfg {Boolean}
+     */
+    keepRaw: false,
+    /**
      * Creates new Reader.
      *
      * @param {Object} config (optional) Config object.
@@ -72,6 +77,19 @@ Ext.define('GeoExt.data.reader.WmsDescribeLayer', {
         if (!!data.error) {
             Ext.Error.raise({msg: "Error parsing WMS DescribeLayer", arg: data.error});
         }
+        if (this.keepRaw) {
+            this.raw = data;
+        }
         return this.callParent([data]);
+    },
+
+    /**
+     * @private
+     */
+    destroyReader: function() {
+        var me = this;
+        delete me.raw;
+        this.callParent();
     }
+
 });

--- a/tests/data/reader/WmsCapabilities.html
+++ b/tests/data/reader/WmsCapabilities.html
@@ -40,10 +40,11 @@
         }
 
         function test_read(t) {
-            t.plan(39);
+            t.plan(41);
 
-            var reader = Ext.create("GeoExt.data.reader.WmsCapabilities");
+            var reader = Ext.create("GeoExt.data.reader.WmsCapabilities", {keepRaw: true});
             var records = reader.read({responseXML: doc, responseText: true});
+            t.ok(reader.raw, "raw property set when keepRaw is true");
             var record = records.records[2];
             t.eq(record.get("name"), "tiger:tiger_roads", "correct layer name");
             reader.destroy();
@@ -58,6 +59,7 @@
                 }
             });
             records = reader.read({responseXML: doc, responseText: true});
+            t.ok(!reader.raw, "raw property not populated by default");
             t.eq(records.totalRecords, 22, 'readRecords returns correct number of records');
 
             var layer;

--- a/tests/data/reader/WmsDescribeLayer.html
+++ b/tests/data/reader/WmsDescribeLayer.html
@@ -28,11 +28,12 @@
         }
 
         function test_read(t) {
-            t.plan(4);
+            t.plan(5);
 
-            var reader = Ext.create("GeoExt.data.reader.WmsDescribeLayer");
+            var reader = Ext.create("GeoExt.data.reader.WmsDescribeLayer", {keepRaw: true});
 
             var records = reader.read({responseXML : doc, responseText: true});
+            t.ok(reader.raw, "When keepRaw is true, the raw property is populated");
 
             //1 test
             t.eq(records.totalRecords, 2, 'readRecords returns correct number of records');


### PR DESCRIPTION
which stores the raw parsed result on the reader instance for use by the application. A lot of times an application needs more than what can be expressed in the records of a store. This property allows an application to access the raw parser result from the OpenLayers format.

See also https://github.com/boundlessgeo/gxp/blob/master/src/script/plugins/WMSSource.js#L24:L55 for a bit of background.

TIA for any review. Tests are included.
