### PR TITLE
protocol proxy does not work with feature reader

### DIFF
--- a/src/GeoExt/data/proxy/Protocol.js
+++ b/src/GeoExt/data/proxy/Protocol.js
@@ -117,7 +117,7 @@ Ext.define('GeoExt.data.proxy.Protocol', {
         var scope = o.request.scope;
         var callback = o.request.callback;
         if (response.success()) {
-            var result = o.reader.read(response);
+            var result = o.reader.read(response.features || response);
             Ext.apply(operation, {
                 response: response,
                 resultSet: result

--- a/tests/data/proxy/Protocol.html
+++ b/tests/data/proxy/Protocol.html
@@ -16,6 +16,7 @@
         });
 
         Ext.Loader.syncRequire([
+            'GeoExt.data.reader.Feature',
             'GeoExt.data.proxy.Protocol'
         ]);
 
@@ -79,6 +80,35 @@
             };
             // 8 tests
             proxy.doRequest(Ext.create("Ext.data.Operation", {params: params, arg: arg}), callback, scope);
+        }
+
+        function test_readFeatures(t) {
+            t.plan(1);
+            var response = new OpenLayers.Protocol.Response({
+                code: OpenLayers.Protocol.Response.SUCCESS,
+                features: [new OpenLayers.Feature.Vector(null, {'foo': 'bar'})]
+            });
+            var protocol = new OpenLayers.Protocol({
+                read: function(o) {
+                    o.callback.call(o.scope, response); 
+                }
+            });
+            Ext.define('My.Model', {
+                extend: 'Ext.data.Model',
+                fields: [
+                    {name: 'foo'}
+                ]
+            });
+            var reader = Ext.create("GeoExt.data.reader.Feature");
+            var proxy = Ext.create("GeoExt.data.proxy.Protocol", {
+                model: 'My.Model',
+                protocol: protocol,
+                reader: reader
+            });
+            var callback = function(o) {
+                t.eq(o.resultSet.records[0].get('foo'), "bar", "feature read correctly");
+            };
+            proxy.doRequest(Ext.create("Ext.data.Operation"), callback);
         }
         
         function test_abort(t) {

--- a/tests/list-tests.html
+++ b/tests/list-tests.html
@@ -20,7 +20,6 @@
   <li>data/WmsDescribeLayerStore.html</li>
   <li>data/ScaleStore.html</li>
   <li>data/StyleStore.html</li>
-  <li>data/proxy/Protocol.html</li>
   <li>FeatureRenderer.html</li>
   <li>Form.html</li>
   <li>form/action/Search.html</li>


### PR DESCRIPTION
Opening up a ticket so I don't forget about this, will do PR later, but when using the protocol proxy with a feature reader things don't work. The trick in this case is that the response object has a features array and that needs to be passed in to the reader so e.g.:

```
var result = o.reader.read(response.features || response);
```
