### PR TITLE
SlimerJS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,19 @@
 language: node_js
+
 node_js: 0.10
-# installs dependencies for testing
-install: npm install -g casperjs@1.1.0-beta3
-# command to run tests
-script: casperjs test tests/headless/run-testsuite.js
+
+before_install:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
+install:
+  - npm install -g http-server
+  - npm install -g slimerjs@0.9.2
+  - npm install -g casperjs@1.1.0-beta3
+
+before_script:
+  - http-server -s -a 0.0.0.0 -p 8080 &
+
+script:
+  - casperjs test tests/headless/run-testsuite.js --host=http://0.0.0.0:8080/
+  - ./tests/run-slimerjs.sh

--- a/tests/headless/modules/tawWrapper.js
+++ b/tests/headless/modules/tawWrapper.js
@@ -125,7 +125,7 @@ function runOneTestFunc(name, filename) {
                     results.push({
                         pass: false,
                         msg: msg + debugInfo("t.ok", name, filename)
-                    })
+                    });
                 } else {
                     results.push({pass: true, msg: msg});
                 }

--- a/tests/headless/run-testsuite.js
+++ b/tests/headless/run-testsuite.js
@@ -1,38 +1,25 @@
+
 var fs = require('fs'),
-    system = require('system'),
-    dash = fs.separator,
-    currentFile = system.args[4], // the full path to run-testsuite.js
-    curFileParts = fs.absolute(currentFile).split(dash);
+    host = casper.cli.has('host') ? casper.cli.get('host') : 'http://localhost:8080/',
+    testsPath = host + 'tests/',
+    tawListOfTestsFile = testsPath + 'list-tests.html',
+    modulesPath = fs.workingDirectory + '/tests/headless/modules/';
 
-// remove filename 'run-testsuite.js'
-curFileParts.pop();
-// remove containing folder 'headless' 
-curFileParts.pop();
-
-var basePath = curFileParts.join(dash) + dash;
-var modulePath = basePath  + 'headless' + dash + 'modules' + dash;
-
-// the html file with the links
-var tawListOfTestsFile = basePath + 'list-tests.html';
-
-var strUtil = require(modulePath + 'strUtil'),
+var strUtil = require(modulesPath + 'strUtil'),
     padLeft = strUtil.padLeft,
     padRight = strUtil.padRight;
 
-var tawWrapper = require(modulePath + 'tawWrapper'),
+var tawWrapper = require(modulesPath + 'tawWrapper'),
     getTestFiles = tawWrapper.getTestFiles,
     getTestFunctions = tawWrapper.getTestFunctions,
     runOneTestFunc = tawWrapper.runOneTestFunc;
 
-
 // the variables we'll fill during the first phase and iterate over in the
 // second phase
-var links = [];
-var funcCnt = 0;
-var results = [];
-var total = 0;
-
-
+var links = [],
+    funcCnt = 0,
+    results = [],
+    total = 0;
 
 // Open the TAW-list of urls
 casper.start(tawListOfTestsFile);
@@ -45,7 +32,7 @@ casper.then(function() {
 casper.then(function() {
     links.forEach(function(link) {
         var funcs;
-        casper.thenOpen(basePath + link, function(){
+        casper.thenOpen(testsPath + link, function(){
             funcs = this.evaluate(getTestFunctions);
         });
         casper.then(function() {
@@ -62,7 +49,7 @@ casper.then(function() {
                 );
             }, this);
         });
-        
+
     });
 });
 
@@ -77,7 +64,7 @@ casper.then(function(){
                 } else {
                     var message = padLeft((++cnt), 4) + ") " + result.msg;
                     if (result.skip) {
-                        test.skip(1, message)
+                        test.skip(1, message);
                     } else {
                         test.assert(result.pass, message);
                     }

--- a/tests/run-slimerjs.sh
+++ b/tests/run-slimerjs.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+casperjs --engine=slimerjs test tests/headless/run-testsuite.js --host=http://0.0.0.0:8080/ | tee slimerjs.log
+
+# Figure out the exit code ourselves because Gecko does not allow
+# SlimerJS to do so for now.
+[ -z "`grep ' 0 failed.' slimerjs.log`" ] && ERROR=1
+rm slimerjs.log
+exit $ERROR


### PR DESCRIPTION
Work in progress. This addresses #286 and I would like to discuss how to continue.

The run-testsuite.js has been altered to use the http:// protocol of a static file server (Python SimpleHTTPServer, Node.js http.server) which makes it compatible with SlimerJS. The .travis.yml has been altered to run the test suite via engine PhantomJS and SlimerJS. This leads to two problems:
- Some tests fail with SlimerJS, I haven't checked yet if this is a problem in the code base or in SlimerJS support.
- SlimerJS does not return the correct exit code on error. This is a [known bug](https://github.com/laurentj/slimerjs/issues/50).
