### PR TITLE
fix for duplicated URL params in wmslegend

### DIFF
--- a/src/GeoExt/container/WmsLegend.js
+++ b/src/GeoExt/container/WmsLegend.js
@@ -129,6 +129,7 @@ Ext.define('GeoExt.container.WmsLegend', {
         [layer.params.STYLES].join(",").split(",");
         var idx = Ext.Array.indexOf(layerNames, layerName);
         var styleName = styleNames && styleNames[idx];
+        var params = {};
         // check if we have a legend URL in the record's
         // "styles" data field
         if(styles && styles.length > 0) {
@@ -141,9 +142,10 @@ Ext.define('GeoExt.container.WmsLegend', {
                 !layer.params.SLD && !layer.params.SLD_BODY) {
                 url = styles[0].legend && styles[0].legend.href;
             }
+            params = Ext.apply({}, this.baseParams);
         }
         if(!url) {
-            url = layer.getFullRequestString({
+            var paramObject = Ext.apply({
                 REQUEST: "GetLegendGraphic",
                 WIDTH: null,
                 HEIGHT: null,
@@ -155,9 +157,11 @@ Ext.define('GeoExt.container.WmsLegend', {
                 SRS: null,
                 FORMAT: null,
                 TIME: null
-            });
+            }, this.baseParams);
+            
+            url = layer.getFullRequestString(paramObject);
+            params = {};
         }
-        var params = Ext.apply({}, this.baseParams);
         if (layer.params._OLSALT) {
             // update legend after a forced layer redraw
             params._OLSALT = layer.params._OLSALT;

--- a/tests/container/WmsLegend.html
+++ b/tests/container/WmsLegend.html
@@ -88,7 +88,7 @@
 
             url = l.items.get(1) && l.items.get(1).url;
             t.eq(!!url, true, "legend image loaded even when MapPanel is not rendered at legend instantiation.")
-            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=a&FORMAT=image%2Fpng&foo=bar%20bar";
+            expectedUrl = "/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&FORMAT=image%2Fpng&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=a&foo=bar%20bar";
             t.eq(url, expectedUrl, "GetLegendGraphic url is generated correctly");
             l.destroy()
 
@@ -193,6 +193,36 @@
             delete mapPanel.map.layers[0].params.SLD_BODY;
 
             mapPanel.destroy();
+        }
+
+        // See https://github.com/geoext/geoext2/pull/309
+        function test_baseParamsNoDuplicates(t) {
+            t.plan(3);
+
+            var mapPanel = loadMapPanel(false),
+                layerRec = mapPanel.layers.getAt(0),
+                expExceptionVal = 'i-am-the-only-exception-allowed-in-url',
+                wmsLegendContainer = Ext.create('GeoExt.container.WmsLegend', {
+                    renderTo: 'legendwms',
+                    baseParams: {
+                        EXCEPTIONS: expExceptionVal
+                    },
+                    layerRecord: layerRec
+                });
+
+            mapPanel.render("mappanel");
+
+            var legendUrl = wmsLegendContainer.items.get(1).url;
+
+            var numExceptionParamInUrl = legendUrl.match(/EXCEPTIONS/g).length;
+            var queryObj = Ext.Object.fromQueryString(legendUrl);
+
+            t.eq(numExceptionParamInUrl, 1,
+                    'Parameter occurs only once in URL.');
+            t.ok(Ext.isString(queryObj.EXCEPTIONS),
+                    'Value is a plain string, not an array.')
+            t.eq(queryObj.EXCEPTIONS, expExceptionVal,
+                    'Parameter has expected value.');
         }
 
         function test_update(t) {


### PR DESCRIPTION
This PR fixes the broken behaviour in GeoExt.container.WmsLegend, when baseParams are used.
Before this PR, when using baseParams on instanciation like described in the documentation http://geoext.github.io/geoext2/docs/#!/api/GeoExt.container.WmsLegend-cfg-baseParams and you set the 'EXCEPTIONS' parameter as baseParam to a different value, multiple EXCEPTIONS-parameters will appear in the final URL. 
Example:

```
/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetLegendGraphic&EXCEPTIONS=application%2Fvnd.ogc.se_inimage&FORMAT=image%2Fpng&EXCEPTIONS=application%2Fvnd.ogc.se_xml&LAYER=a&foo=bar%20bar
```

This was happening because of the usage of Ext.urlAppend with parameteres which have not been cleanly 'merged' with Ext.apply.
This fix handles this case and applies parameters, so that they dont get duplicated in the final request url.
Test has also been fixed to reflect the change in order of the params.
