### PR TITLE
Fixed the test for data/reader/WfsCapabilities.js

### DIFF
--- a/src/GeoExt/data/reader/WfsCapabilities.js
+++ b/src/GeoExt/data/reader/WfsCapabilities.js
@@ -45,6 +45,18 @@ Ext.define('GeoExt.data.reader.WfsCapabilities', {
         }
     },
 
+    config: {
+        /**
+         *
+         */
+        layerOptions: null,
+
+        /**
+         *
+         */
+        protocolOptions: null
+    },
+
     /**
      * Gets the records.
      *
@@ -127,7 +139,7 @@ Ext.define('GeoExt.data.reader.WfsCapabilities', {
                     protocol: new OpenLayers.Protocol.WFS(protocolOptions),
                     strategies: [new OpenLayers.Strategy.Fixed()]
                 };
-                var metaLayerOptions = this.layerOptions;
+                var metaLayerOptions = this.getLayerOptions();
                 if (metaLayerOptions) {
                     Ext.apply(layerOptions, Ext.isFunction(metaLayerOptions) ?
                         metaLayerOptions() : metaLayerOptions);


### PR DESCRIPTION
Adjustments on the class where needed.
Using the config object now to get Getters and Setters.
This is needed for ExtJS5 and also supported by ExtJS4, so we probably should use it.
