### PR TITLE
Fix the tests of the WMSDescribeLayer reader

### DIFF
--- a/src/GeoExt/data/reader/WmsDescribeLayer.js
+++ b/src/GeoExt/data/reader/WmsDescribeLayer.js
@@ -80,6 +80,13 @@ Ext.define('GeoExt.data.reader.WmsDescribeLayer', {
      *     as a cache of Ext.data.Model objects.
      */
     readRecords: function(data) {
+        if (data instanceof Ext.data.ResultSet) {
+            // we get into the readRecords method twice,
+            // called by Ext.data.reader.Reader#read:
+            // check if we already did our work in a previous run
+            return data;
+        }
+
         if(typeof data === "string" || data.nodeType) {
             data = this.format.read(data);
         }

--- a/tests/data/reader/WmsDescribeLayer.html
+++ b/tests/data/reader/WmsDescribeLayer.html
@@ -40,8 +40,9 @@
             var records = reader.read({responseXML : doc, responseText: true});
             t.ok(reader.raw, "When keepRaw is true, the raw property is populated");
 
+            var total = GeoExt.isExt4 ? records.total : records.getTotal();
             //1 test
-            t.eq(records.totalRecords, 2, 'readRecords returns correct number of records');
+            t.eq(total, 2, 'readRecords returns correct number of records');
             
             var record = records.records[0];
 


### PR DESCRIPTION
Again we need to guard against multiple `readRecords`-calls and the access of the total property needs to be done with the `getTotal()`-ethod