### PR TITLE
Make tree compatible to ExtJS 5

### DIFF
--- a/src/GeoExt/tree/Panel.js
+++ b/src/GeoExt/tree/Panel.js
@@ -25,7 +25,8 @@ Ext.define('GeoExt.tree.Panel', {
     alias: 'widget.gx_treepanel',
     requires: [
         'GeoExt.tree.Column',
-        'GeoExt.tree.View'
+        'GeoExt.tree.View',
+        'GeoExt.tree.Util'
     ],
     viewType: 'gx_treeview',
     
@@ -44,6 +45,8 @@ Ext.define('GeoExt.tree.Panel', {
                 dataIndex: me.displayField         
             }];
         }
+        // bind checkchange for tree nodes to steer visibility of the layers
+        me.on('checkchange', GeoExt.tree.Util.updateLayerVisibilityByNode);
 
         me.callParent();
     }

--- a/src/GeoExt/tree/Util.js
+++ b/src/GeoExt/tree/Util.js
@@ -1,0 +1,56 @@
+Ext.define('GeoExt.tree.Util', {
+    statics: {
+        /**
+         * Updates the visibility of the layer that is connected to given
+         * node.
+         *
+         * @private
+         */
+        updateLayerVisibilityByNode: function(node, checked) {
+            if(checked != node.get('layer').getVisibility()) {
+                node._visibilityChanging = true;
+                var layer = node.get('layer');
+                if(checked && layer.isBaseLayer && layer.map) {
+                    layer.map.setBaseLayer(layer);
+                } else if(!checked && layer.isBaseLayer && layer.map &&
+                          layer.map.baseLayer && layer.id == layer.map.baseLayer.id) {
+                    // Must prevent the unchecking of radio buttons
+                    node.set('checked', layer.getVisibility());
+                } else {
+                    layer.setVisibility(checked);
+                }
+                delete node._visibilityChanging;
+            }
+            GeoExt.tree.Util.enforceOneLayerVisible(node);
+        },
+
+        /**
+         *
+         */
+        enforceOneLayerVisible: function(node) {
+            var attributes = node.data;
+            var group = attributes.checkedGroup;
+            // If we are in the baselayer group, the map will take care of
+            // enforcing visibility.
+            if(group && group !== "gx_baselayer") {
+                var layer = node.get('layer');
+                var checkedNodes = node.getOwnerTree().getChecked();
+                var checkedCount = 0;
+                // enforce "not more than one visible"
+                Ext.each(checkedNodes, function(n){
+                    var l = n.data.layer;
+                    if(!n.data.hidden && n.data.checkedGroup === group) {
+                        checkedCount++;
+                        if(l != layer && attributes.checked) {
+                            l.setVisibility(false);
+                        }
+                    }
+                });
+                // enforce "at least one visible"
+                if(checkedCount === 0 && attributes.checked == false) {
+                    layer.setVisibility(true);
+                }
+            }
+        }
+    }
+});


### PR DESCRIPTION
Bind a checkchange handler for tree nodes for syncing layer visibility and
base layer state. In order to access the handlers they had to be moved to
a new utility file.

With this the 2 tree examples work. Tests will follow.