### PR TITLE
Fix the tests of the WMSCapabilities and the WMC reader

### DIFF
--- a/src/GeoExt/data/LayerModel.js
+++ b/src/GeoExt/data/LayerModel.js
@@ -56,6 +56,6 @@ Ext.define('GeoExt.data.LayerModel',{
      * @return {OpenLayers.Layer}
      */
     getLayer: function() {
-        return (GeoExt.isExt4) ? this.raw : this.data;
+        return this.raw;
     }
 });

--- a/src/GeoExt/data/reader/Wmc.js
+++ b/src/GeoExt/data/reader/Wmc.js
@@ -24,6 +24,10 @@ Ext.define('GeoExt.data.reader.Wmc', {
         'GeoExt.Version'
     ],
 
+    config: {
+        preserveRawData: true
+    },
+
     /**
      * Creates new Reader.
      *

--- a/src/GeoExt/data/reader/WmsCapabilities.js
+++ b/src/GeoExt/data/reader/WmsCapabilities.js
@@ -29,6 +29,11 @@ Ext.define('GeoExt.data.reader.WmsCapabilities', {
     requires: [
         'GeoExt.Version'
     ],
+
+    config: {
+        preserveRawData: true
+    },
+
     /**
      * Creates new Reader.
      *


### PR DESCRIPTION
The particular readers are now configured with `preserveRawData: true`.

This PR also again changes the `LayerModel` method `getLayer` and mostly reverts it back to what it was in GeoExt2.0.x.