### PR TITLE
Fix travis tests errors partially

### DIFF
--- a/src/GeoExt/data/reader/Attribute.js
+++ b/src/GeoExt/data/reader/Attribute.js
@@ -121,7 +121,7 @@ Ext.define('GeoExt.data.reader.Attribute', {
                 }
             });
         }
-        me.callParent(config);
+        me.callParent([config]);
     },
 
     /**

--- a/tests/headless/modules/tawWrapper.js
+++ b/tests/headless/modules/tawWrapper.js
@@ -118,13 +118,14 @@ function runOneTestFunc(name, filename) {
             }
             return a === b;
         },
-        debugInfo = function(mockMethod, testName, filename, other) {
+        debugInfo = function(mockMethod, testName, filename, other, dump) {
             return [
                 " [",
                 mockMethod + ", ",
                 testName + "(t), ",
                 filename,
                 (other ? (', ' + other) : ''),
+                (dump ? (', dump: ' + JSON.stringify(dump)) : ''),
                 "]"
             ].join("");
         },
@@ -147,7 +148,8 @@ function runOneTestFunc(name, filename) {
                         msg: msg +
                             debugInfo(
                                 "t.eq", name, filename,
-                                "exp: " + exp + ", got: " + got
+                                "exp: " + exp + ", got: " + got,
+                                Array.prototype.slice.call(arguments)
                             )
                     });
                 } else {


### PR DESCRIPTION
With this in, we at least can execute more tests on travis unti the CI fails.

It fails at the `protocol.Proxy` tests, which fail for a reason. I doubt that we have finished the work on that class.