### PR TITLE
Round width/height when syncing the size.

### DIFF
--- a/src/GeoExt/panel/PrintMap.js
+++ b/src/GeoExt/panel/PrintMap.js
@@ -331,7 +331,7 @@ Ext.define('GeoExt.panel.PrintMap', {
             height = targetHeight;
         }
 
-        return {width: width, height: height};
+        return {width: Math.round(width), height: Math.round(height)};
     },
 
     /**


### PR DESCRIPTION
When on Windows, the fractional part of a calculated width / height
somehow got stripped away by ExtJS, leading to tiny differences in
the resulting ratio of the print map panel.

When we always round the calculated values, the ratio is fine on all
operating systems.

IE 11 and 9 now is green for me (remember to turn of the compatibility view...)

![ie11-all-tests-passed](https://cloud.githubusercontent.com/assets/227934/5854258/222d7630-a22c-11e4-80dd-5eb209934dde.png)

![ie-9-all-tests-green](https://cloud.githubusercontent.com/assets/227934/5854323/e4d36f5a-a22c-11e4-8832-f6c07b0edf78.png)
