### PR TITLE
Prevent leaking event bindings of dynamic legend panels. 

### DIFF
--- a/src/GeoExt/container/VectorLegend.js
+++ b/src/GeoExt/container/VectorLegend.js
@@ -163,10 +163,10 @@ Ext.define('GeoExt.container.VectorLegend', {
 
         if (this.layerRecord) {
             this.layer = this.layerRecord.getLayer();
-            if (this.layer.map) {
+            if (this.layer && this.layer.map) {
                 this.map = this.layer.map;
-                this.currentScaleDenominator = this.layer.map.getScale();
-                this.layer.map.events.on({
+                this.currentScaleDenominator = this.map.getScale();
+                this.map.events.on({
                     "zoomend": this.onMapZoom,
                     scope: this
                 });
@@ -274,7 +274,7 @@ Ext.define('GeoExt.container.VectorLegend', {
     */
     onMapZoom: function() {
         this.setCurrentScaleDenominator(
-            this.layer.map.getScale()
+            this.map.getScale()
         );
     },
 
@@ -696,8 +696,8 @@ Ext.define('GeoExt.container.VectorLegend', {
                     scope: this
                 });
             }
-            if (this.layer.map && this.layer.map.events) {
-                this.layer.map.events.un({
+            if (this.map && this.map.events) {
+                this.map.events.un({
                     "zoomend": this.onMapZoom,
                     scope: this
                 });
@@ -745,8 +745,8 @@ Ext.define('GeoExt.container.VectorLegend', {
         for (var i=0, len=records.length; i<len; i++) {
             var record = records[i];
             if (record.getLayer() === this.layer) {
-                if (this.layer.map && this.layer.map.events) {
-                    this.layer.map.events.on({
+                if (this.map && this.map.events) {
+                    this.map.events.on({
                         "zoomend": this.onMapZoom,
                         scope: this
                     });

--- a/tests/panel/Legend.html
+++ b/tests/panel/Legend.html
@@ -145,7 +145,7 @@
         }
 
         function test_addremove(t) {
-            t.plan(4);
+            t.plan(8);
             var mapPanel = loadMapPanel();
             var lp  = Ext.create("GeoExt.panel.Legend", {
                 renderTo: 'legendpanel'});
@@ -167,12 +167,36 @@
             mapPanel.map.removeLayer(mapPanel.map.layers[0]);
             t.eq(lp.items.length, 2, "Removing the layer really removes the legend from the panel");
 
+            trouble = false;
+            try {
+                mapPanel.map.zoomIn();
+            } catch (err) {
+                trouble = true;
+            }
+            t.ok(!trouble, "Removed WMS layer did not leak event bindings");
+
+            layer = new OpenLayers.Layer.Vector('test4');
+            mapPanel.map.addLayer(layer);
+
+            t.eq(lp.items.length, 3, "A vector layer will be added");
+
+            mapPanel.map.removeLayer(layer);
+            t.eq(lp.items.length, 2, "Removing the vector layer really removes the legend from the panel");
+
+            trouble = false;
+            try {
+                mapPanel.map.zoomIn();
+            } catch (err) {
+                trouble = true;
+            }
+            t.ok(!trouble, "Removed vector layer did not leak event bindings");
+
             lp.destroy();
             mapPanel.destroy();
         }
-        
+
         function test_unsupported(t) {
-            
+
             t.plan(1);
             var mapPanel = Ext.create('GeoExt.panel.Map', {
                 title: "GeoExt MapPanel",
@@ -186,11 +210,11 @@
                 center: new OpenLayers.LonLat(5, 45),
                 zoom: 4
             });
-            
+
             var legendPanel = Ext.create("GeoExt.panel.Legend", {
                 renderTo: "legendpanel"
             });
-            
+
             var map = mapPanel.map;
             var layer = map.layers[1];
             var trouble;
@@ -200,10 +224,10 @@
                 trouble = true;
             }
             t.ok(!trouble, "removed layer without issues");
-            
+
             legendPanel.destroy();
             mapPanel.destroy();
-            
+
         }
 
         function test_clear(t) {


### PR DESCRIPTION
A dynamic legend panel will cause an error when a vector layer is added and remove after init of the component. The behavior can be observed via the [online examples](http://geoext.github.io/geoext2/examples/legendpanel/legendpanel.html) feeding the following to the console:
````
mapPanel.layers.add(GeoExt.data.LayerModel.createFromLayer(new OpenLayers.Layer.Vector()));
mapPanel.layers.removeAt(3);
mapPanel.map.zoomOut();
````
This will cause ```Uncaught TypeError: Cannot read property 'map' of null``` by calling the ```VectorLegend:onMapZoom``` event handler of the disposed vector legend.

To fix this the cached map property of the legend is used to unbind all event handlers.