### PR TITLE
Add visual feedback of layers out of range to tree panel

### DIFF
--- a/examples/tree/tree.js
+++ b/examples/tree/tree.js
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2008-2014 The Open Source Geospatial Foundation
- * 
+ *
  * Published under the BSD license.
  * See https://github.com/geoext/geoext2/blob/master/license.txt for the full
  * text of the license.
@@ -60,6 +60,17 @@ Ext.application({
                         format: "image/png"
                     }, {
                         isBaseLayer: false,
+                        resolutions: [
+                            1.40625,
+                            0.703125,
+                            0.3515625,
+                            0.17578125,
+                            0.087890625,
+                            0.0439453125,
+                            0.02197265625,
+                            0.010986328125,
+                            0.0054931640625
+                        ],
                         buffer: 0
                     }
                 ),
@@ -110,7 +121,7 @@ Ext.application({
 
         // create our own layer node UI class, using the TreeNodeUIEventMixin
         //var LayerNodeUI = Ext.extend(GeoExt.tree.LayerNodeUI, new GeoExt.tree.TreeNodeUIEventMixin());
-        
+
         /*var treeConfig = [
             {nodeType: 'gx_layercontainer', layerStore: map.layers}
         {
@@ -160,7 +171,7 @@ Ext.application({
                 ]
             }
         });
-        
+
         var layer;
 
         // create the tree with the configuration from above
@@ -189,7 +200,7 @@ Ext.application({
                 }
             }]
         });
-    
+
         Ext.create('Ext.Viewport', {
             layout: "fit",
             hideBorders: true,

--- a/resources/css/tree-access.css
+++ b/resources/css/tree-access.css
@@ -7,3 +7,8 @@
 .gx-tree-baselayer-icon {
     background-image: url('../../resources/images/default/map.png');
 }
+
+.gx-tree-row-disabled .x-tree-node-text {
+    opacity: 0.7;
+    font-style: italic;
+}

--- a/resources/css/tree-classic.css
+++ b/resources/css/tree-classic.css
@@ -7,3 +7,8 @@
 .gx-tree-baselayer-icon {
     background-image: url('../../resources/images/default/map.png');
 }
+
+.gx-tree-row-disabled .x-tree-node-text {
+    opacity: 0.7;
+    font-style: italic;
+}

--- a/resources/css/tree-gray.css
+++ b/resources/css/tree-gray.css
@@ -7,3 +7,8 @@
 .gx-tree-baselayer-icon {
     background-image: url('../../resources/images/default/map.png');
 }
+
+.gx-tree-row-disabled .x-tree-node-text {
+    opacity: 0.7;
+    font-style: italic;
+}

--- a/resources/css/tree-neptune.css
+++ b/resources/css/tree-neptune.css
@@ -7,3 +7,8 @@
 .gx-tree-baselayer-icon {
     background-image: url('../../resources/images/default/map.png');
 }
+
+.gx-tree-row-disabled .x-tree-node-text {
+    opacity: 0.7;
+    font-style: italic;
+}

--- a/src/GeoExt/data/LayerTreeModel.js
+++ b/src/GeoExt/data/LayerTreeModel.js
@@ -62,7 +62,8 @@ Ext.define('GeoExt.data.LayerTreeModel',{
         {name: 'container'},
         {name: 'checkedGroup', type: 'string'},
         {name: 'fixedText', type: 'bool'},
-        {name: 'component'}
+        {name: 'component'},
+        {name: 'disabled', type: 'bool', defaultValue: 'false'}
     ],
     proxy: {
         type: "memory"

--- a/src/GeoExt/tree/LayerNode.js
+++ b/src/GeoExt/tree/LayerNode.js
@@ -34,7 +34,7 @@ Ext.define('GeoExt.tree.LayerNode', {
     /**
      * The init method is invoked after initComponent method has been run for
      * the client Component. It performs plugin initialization.
-     * 
+     *
      * @param {Ext.Component} target The client Component which owns this
      *     plugin.
      * @private
@@ -57,10 +57,16 @@ Ext.define('GeoExt.tree.LayerNode', {
         }
 
         target.on('afteredit', this.onAfterEdit, this);
+
         layer.events.on({
-            "visibilitychanged": this.onLayerVisibilityChanged,
+            'visibilitychanged': this.onLayerVisibilityChanged,
             scope: this
         });
+
+        if (!layer.alwaysInRange && layer.map) {
+            layer.map.events.register('moveend', this, this.onMapMoveend);
+        }
+
         this.enforceOneVisible();
     },
 
@@ -88,6 +94,16 @@ Ext.define('GeoExt.tree.LayerNode', {
         if(!this._visibilityChanging) {
             this.target.set('checked', this.target.get('layer').getVisibility());
         }
+    },
+
+    /**
+     *  handler for map moveend events to determine if node should be
+     *  disabled or enabled
+     *
+     * @private
+     */
+    onMapMoveend: function(e) {
+        this.target.set('disabled', !this.target.get('layer').inRange);
     },
 
     /**

--- a/src/GeoExt/tree/View.js
+++ b/src/GeoExt/tree/View.js
@@ -44,6 +44,10 @@ Ext.define('GeoExt.tree.View', {
         return me.callParent(arguments);
     },
 
+    getRowClass: function(record, rowIndex, rowParams, store) {
+        return record.get('disabled') ? 'gx-tree-row-disabled' : '';
+    },
+
     /**
      * Called when an item updates or is added.
      *
@@ -66,8 +70,8 @@ Ext.define('GeoExt.tree.View', {
 
     /**
      * Called when a node is being rendered.
-     * 
-     * 
+     *
+     *
      */
     onNodeRendered: function(node) {
         var me = this;


### PR DESCRIPTION
I would like to add some visual feedback for layers that are scale-based and move out of range of the maps resolution. It may be worthwhile to have in the base library as well.

 This is a first draft which makes sure active layers that become non-visible to resolution constraints are unchecked and vice-versa. I'm unsure if this is the most user friendly approach though.