### PR TITLE
Adopt minimal Sencha Cmd package requirements

### DIFF
--- a/.sencha/package/sencha.cfg
+++ b/.sencha/package/sencha.cfg
@@ -1,0 +1,60 @@
+# The name of the package - should match the "name" property in ./package.json
+#
+package.name=GeoExt
+
+# The namespace to which this package's SASS corresponds. The default value of
+# "Ext" means that the files in ./sass/src (and ./sass/var) match classes in
+# the Ext" root namespace. In other words, "Ext.panel.Panel" maps to
+# ./sass/src/panel/Panel.scss.
+#
+# To style classes from any namespace, set this to blank. If this is blank,
+# then to style "Ext.panel.Panel" you would put SASS in
+# ./sass/src/Ext/panel/Panel.scss.
+#
+package.sass.namespace=
+
+# This is the comma-separated list of folders where classes reside. These
+# classes must be explicitly required to be included in the build.
+#
+package.classpath=${package.dir}/src/GeoExt
+
+# This is the comma-separated list of folders of overrides. All files in this
+# path will be given a tag of "packageOverrides" which is automatically
+# required in generated apps by the presence of this line in app.js:
+#
+#   //@require @packageOverrides
+#
+package.overrides=${package.dir}/src/GeoExt/overrides
+
+# This is the folder where SASS "src" resides. This is searched for SCSS
+# files that match the JavaScript classes used by the application.
+#
+package.sass.srcpath=${package.dir}/sass/src
+
+# This is the folder where SASS "vars" resides. This is searched for SCSS
+# files that match the JavaScript classes used by the application.
+#
+package.sass.varpath=${package.dir}/sass/var
+
+# This file is automatically imported into the SASS build before "vars".
+#
+package.sass.etcpath=${package.dir}/sass/etc/all.scss
+
+# This is the folder in which to place "sencha packaage build" output.
+#
+package.build.dir=${package.dir}/build
+
+# The folder that contains example application(s) for this package.
+#
+package.examples.dir=${package.dir}/examples
+
+# The folder that contains sub-packages of this package. Only valid for "framework"
+# package type.
+#
+package.subpkgs.dir=${package.dir}/packages
+
+#==============================================================================
+# Custom Properties - Place customizations below this line to avoid merge
+# conflicts with newer versions
+
+package.cmd.version=5.0.1.231

--- a/guides/single_file_build/README.md
+++ b/guides/single_file_build/README.md
@@ -1,3 +1,38 @@
+# Sencha Cmd (GeoExt as an ExtJS package)
+
+GeoExt is an ExtJS package and can be used in tandem with the Sencha Cmd tool to produce optimized one file builds of your app:
+
+After initializing your ExtJS workspace and generating your app, you may add
+GeoExt as a package by cloning it into `packages/GeoExt` of your workspace. The name is important here, as otherwise the `GeoExt` package will not be recognized in your development environment. Secondly, to make the GeoExt classes available to your app you will have to add 'GeoExt' as a requirement in your apps `app.json` configuration file.
+
+You may now `sencha app watch` your apps directory and start requiring GeoExt classes. Via `sencha app build` you can easily generate custom builds of your app that only comprises ExtJS and GeoExt classes that you actually use.
+
+A simple workflow to create a new workspace and app may look as following (the `sencha` command needs to be available in your class path):
+````
+# generate workspace in directory "test"
+sencha --sdk ~/Downloads/ext-5.1.0 generate workspace test
+
+# switch to workspace dir
+cd test
+
+# generate app "TestApp" in directoy "appdir"
+sencha --sdk ~/Downloads/ext-5.1.0 generate app TestApp appdir
+
+# clone GeoExt package into folder "package/GeoExt" of your workspace
+git clone https://github.com/geoext/geoext2.git packages/GeoExt
+
+# edit app.json in appdir to require GeoExt package
+...
+"requires": [
+    "GeoExt"
+],
+...
+
+# watch your app directory and start editing
+cd appdir
+sencha app watch
+````
+
 # Sencha Cmd
 
 Assuming that you have Ext JS 4 SDK at the parent path ../ext-4.2.1.883 you can create a compressed full single file build with the following command line:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
-  "name": "geoext2",
-  "version": "2.0.4-dev",
+  "name": "GeoExt",
+  "type": "code",
+  "version": "2.0.4",
+  "compatVersion": "2.0.3",
   "description": "A JavaScript Toolkit for Rich Web Mapping Applications based on OpenLayers and ExtJS.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
This PR aims to be less intrusive than #302 while still adding support for Sencha CMD. It only adds one configuration file and some docs (which may be extended in the future).

To play nice with Cmd the following changes had to be made to the newly added package.json:
- Cmd only allows numeric version so I dropped the `-dev` suffix
- `type` needs to be set to code
- `compatVersion` will probably be helpful with upgrading to future versions

I tried it with an existing application (ExtJS 4.2.1) as well as with a newly generated test app (ExtJS 5.1).