### PR TITLE
Using group optional attribute to create an hierarchical layer tree

### DIFF
--- a/examples/tree/tree-hierarchy.html
+++ b/examples/tree/tree-hierarchy.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>GeoExt Tree Components</title>
+
+        <!-- ExtJS -->
+        <script type="text/javascript" src="../include-ext.js"></script>
+        <script type="text/javascript" src="../options-toolbar.js"></script>
+
+        <!-- Basic example styling -->
+        <link rel="stylesheet" type="text/css" href="../shared/example.css" />
+
+        <!-- Load specific css based on selected theme -->
+        <script src="../shared/theme.js"></script>
+
+        <!-- You should definitely consider using a custom single-file version of OpenLayers -->
+        <script src="http://openlayers.org/api/2.13.1/OpenLayers.js"></script>
+
+        <script type="text/javascript" src="../loader.js"></script>
+        <script type="text/javascript" src="tree-hierarchy.js"></script>
+
+    </head>
+    <body>
+        <div id="desc">
+            <h1>GeoExt.tree Components</h1>
+
+            <p>This example shows how to work with a hierarchy layer tree.</p>
+
+            <p>Each layer can have an optional <code>group</code> attribute. The <code>group</code> attribute can have <code>'/'</code> to create the hierarchy, like:
+            <pre><code>group: 'Additional layers/World/Administrative'</code></pre>
+            </p>
+
+            <p>If no group attribute is assigned, the layer goes by to either the <code>baseLayers</code> or <code>otherLayers</code> group. The default labels for these two groups are:
+
+               <pre><code>baseLayersText: "Base layers",
+otherLayersText: "Other layers"
+        </code></pre>
+
+            These labels can be changed.
+            </p>
+
+
+
+
+
+
+            <p>The js is not minified so it is readable. See
+            <a href="tree-hierarchy.js">tree-hierarchy.js</a>.</p>
+
+        </div>
+    </body>
+</html>

--- a/examples/tree/tree-hierarchy.js
+++ b/examples/tree/tree-hierarchy.js
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2008-2015 The Open Source Geospatial Foundation
+ *
+ * Published under the BSD license.
+ * See https://github.com/geoext/geoext2/blob/master/license.txt for the full
+ * text of the license.
+ */
+
+Ext.require([
+    'Ext.container.Viewport',
+    'Ext.layout.container.Border',
+    'GeoExt.tree.Panel',
+    'Ext.tree.plugin.TreeViewDragDrop',
+    'GeoExt.panel.Map',
+    'GeoExt.tree.OverlayLayerContainer',
+    'GeoExt.tree.BaseLayerContainer',
+    'GeoExt.data.LayerTreeModel',
+    'GeoExt.tree.View',
+    'GeoExt.tree.Column',
+    'GeoExt.tree.LayerTreeBuilder'
+]);
+
+var mapPanel, tree;
+
+Ext.application({
+    name: 'Tree',
+    launch: function() {
+        // create a map panel with some layers that we will show in our layer tree
+        // below.
+        mapPanel = Ext.create('GeoExt.panel.Map', {
+            border: true,
+            region: "center",
+            // we do not want all overlays, to try the OverlayLayerContainer
+            map: {allOverlays: false},
+            center: [14, 37.5],
+            zoom: 7,
+            layers: [
+                new OpenLayers.Layer.WMS("Global Imagery",
+                    "http://maps.opengeo.org/geowebcache/service/wms", {
+                        layers: "bluemarble",
+                        format: "image/png8"
+                    }, {
+                        buffer: 0,
+                        visibility: false,
+                        group: 'World base maps/Imagery'
+                    }
+                ),
+                new OpenLayers.Layer.WMS("OpenStreetMap WMS",
+                    "http://ows.terrestris.de/osm/service?",
+                    {layers: 'OSM-WMS'},
+                    {
+                        attribution: '&copy; terrestris GmbH & Co. KG <br>' +
+                            'Data &copy; OpenStreetMap ' +
+                            '<a href="http://www.openstreetmap.org/copyright/en"' +
+                            'target="_blank">contributors<a>',
+                        group: 'World base maps/Vector'
+                    }
+                ),
+                new OpenLayers.Layer.WMS("Country Borders",
+                    "http://ows.terrestris.de/geoserver/osm/wms", {
+                        layers: "osm:osm-country-borders",
+                        transparent: true,
+                        format: "image/png"
+                    }, {
+                        isBaseLayer: false,
+                        resolutions: [
+                            1.40625,
+                            0.703125,
+                            0.3515625,
+                            0.17578125,
+                            0.087890625,
+                            0.0439453125,
+                            0.02197265625,
+                            0.010986328125,
+                            0.0054931640625
+                        ],
+                        buffer: 0,
+                        group: 'Additional layers/World/Administrative'
+                    }
+                ),
+                new OpenLayers.Layer.WMS("Gas Stations",
+                    "http://ows.terrestris.de/geoserver/osm/wms", {
+                        layers: "osm:osm-fuel",
+                        transparent: true,
+                        format: "image/png"
+                    }, {
+                        isBaseLayer: false,
+                        buffer: 0
+                    }
+                ),
+                new OpenLayers.Layer.WMS("Bus Stops",
+                    "http://ows.terrestris.de/osm-haltestellen?",
+                    {
+                        layers: 'OSM-Bushaltestellen',
+                        format: 'image/png',
+                        transparent: true
+                    },
+                    {
+                        singleTile: true,
+                        visibility: false
+                    }
+                )
+            ]
+        });
+
+        var novatree = Ext.create('GeoExt.tree.LayerTreeBuilder', {
+            enableWmsLegends: false,
+            enableVectorLegends: false,
+            otherLayersText: 'Utilities',
+            border: true,
+            layerStore: mapPanel.layers,
+            region: "west",
+            title: "Layers",
+            width: 250,
+            split: true,
+            collapsible: true,
+            collapseMode: "mini",
+            autoScroll: true
+        });
+
+        Ext.create('Ext.Viewport', {
+            layout: "fit",
+            hideBorders: true,
+            items: {
+                layout: "border",
+                deferredRender: false,
+                items: [mapPanel, novatree, {
+                    contentEl: "desc",
+                    region: "east",
+                    bodyStyle: {"padding": "5px"},
+                    collapsible: true,
+                    collapseMode: "mini",
+                    split: true,
+                    width: 200,
+                    title: "Description"
+                }]
+            }
+        });
+    }
+});

--- a/src/GeoExt/tree/LayerGroupContainer.js
+++ b/src/GeoExt/tree/LayerGroupContainer.js
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2008-2012 The Open Source Geospatial Foundation
+ *
+ * Published under the BSD license.
+ * See https://github.com/geoext/geoext2/blob/master/license.txt for the full
+ * text of the license.
+ */
+
+/*
+ * @include GeoExt/tree/LayerContainer.js
+ * @include GeoExt/container/WmsLegend.js
+ * @include GeoExt/container/VectorLegend.js
+ * @include GeoExt/data/LayerStore.js
+ */
+
+/**
+ *
+ */
+Ext.define('GeoExt.tree.LayerGroupContainer', {
+    extend: 'GeoExt.tree.LayerContainer',
+    requires: [
+        'GeoExt.container.WmsLegend',
+        'GeoExt.container.VectorLegend',
+        'GeoExt.data.LayerStore'
+    ],
+    alias: 'plugin.gx_layergroupcontainer',
+    
+    defaultText: 'Layers',
+
+    enableLegends: true,
+
+    enableWmsLegends: true,
+
+    enableVectorLegends: true,
+
+    layerGroup: null,
+    
+    /**
+     * @private
+     */
+    init: function(target) {
+        var me = this,
+            loader = me.loader,
+            createNode,
+            superProto = GeoExt.tree.LayerLoader.prototype;
+
+        // set the 'createNode' method for the loader
+        if (me.enableLegends) {
+            createNode = function(attr) {
+                if (attr.layer.href)  {
+                    attr.href = attr.layer.href;
+                    attr.cls = 'linknode';
+                    if (attr.layer.hrefTarget) attr.hrefTarget = attr.layer.hrefTarget;
+                }
+                if (attr.layer.qtip) attr.qtip = attr.layer.qtip;
+                var record = this.store.getByLayer(attr.layer),
+                    layer = record.getLayer();
+
+                if (layer instanceof OpenLayers.Layer.WMS &&
+                    me.enableWmsLegends
+                ) {
+                    attr.component = {
+                        xtype: "gx_wmslegend",
+                        layerRecord: record,
+                        showTitle: false,
+                        hidden: !layer.visibility || layer.hideInLegend
+                            || !layer.inRange,
+                        cls: "gx-layertreebuilder-legend"
+                    };
+                } else if (layer instanceof OpenLayers.Layer.Vector &&
+                           me.enableVectorLegends
+                ) {
+                    attr.component = {
+                        xtype: "gx_vectorlegend",
+                        layerRecord: record,
+                        showTitle: false,
+                        hidden: !layer.visibility || layer.hideInLegend
+                            || !layer.inRange,
+                        cls: "gx-layertreebuilder-legend"
+                    };
+                }
+
+                if (layer.hideInLegend) {
+                    record.set("hideInLegend", layer.hideInLegend);
+                }
+
+                return superProto.createNode.call(this, attr);
+            }
+        }
+        else {
+            createNode = function(attr) {
+                return superProto.createNode.call(this, attr);
+            }
+        } 
+
+        // set the loader
+        me.loader = Ext.applyIf(loader || {}, {
+            baseAttrs: Ext.applyIf((loader && loader.baseAttrs) || {}, {
+                uiProvider: "custom_ui",
+                layerGroup: this.layerGroup
+            }),
+            createNode: createNode,
+            filter: function(record) {
+                var layer = record.getLayer();
+                return layer.displayInLayerSwitcher === true &&
+                    layer.options.group === this.baseAttrs.layerGroup;
+            }
+        });
+
+        me.callParent(arguments);
+    }
+});

--- a/src/GeoExt/tree/LayerTreeBuilder.js
+++ b/src/GeoExt/tree/LayerTreeBuilder.js
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2008-2012 The Open Source Geospatial Foundation
+ *
+ * Published under the BSD license.
+ * See https://github.com/geoext/geoext2/blob/master/license.txt for the full
+ * text of the license.
+ */
+
+/*
+ * @include GeoExt/tree/Panel.js
+ * @include GeoExt/tree/LayerGroupContainer.js
+ * @include GeoExt/data/LayerStore.js
+ * @include GeoExt/panel/Map.js
+ */
+
+Ext.define('GeoExt.tree.LayerTreeBuilder', {
+    extend: 'GeoExt.tree.Panel',
+    requires: [
+        'GeoExt.data.LayerStore',
+        'GeoExt.panel.Map',
+        'GeoExt.tree.LayerGroupContainer'
+    ],
+    alias: 'widget.gx_layertreebuilder',
+
+    /** 
+     * @cfg {String} Text to display the default "base layers" group (i18n).
+     */
+    baseLayersText: "Base layers",
+
+    /** 
+     * @cfg {String} Text to display the default "other layers" group (i18n).
+     */
+    otherLayersText: "Other layers",
+
+    layerStore: null,
+
+    enableWmsLegends: true,
+
+    enableVectorLegends: true,
+
+    checkableContainerGroupNodes: true,
+
+    checkableLeafGroupNodes: true,
+
+    initComponent: function(){
+        Ext.apply(this, {
+            autoScroll: true,
+            lines: false,
+            rootVisible: false,
+            store: Ext.create('Ext.data.TreeStore', {
+                  model: 'GeoExt.data.LayerTreeModel'
+            })
+        });
+
+        // Don't do anything if a layerstore hasn't been provided yet.
+        // Developer will need to set the layerStore and call 
+        // initLayerStore again
+        if (this.layerStore) {
+            this.initLayerStore();
+        }
+
+        this.callParent(arguments);
+    },
+
+    initLayerStore: function() {
+
+        // Process new layers as they come in
+        this.layerStore.on({
+            "add": this.onLayerAdded,
+            scope: this
+        });
+
+        // after the layertree has been rendered, look for already added
+        // layer records, else, wait till afterrender event has fired
+        if (this.rendered) {
+            this.processLayerStore();
+        } else {
+            // after the layertree has been rendered, look for already added
+            // layer records            
+            this.on({
+                "afterrender": this.processLayerStore, 
+                scope: this
+            });
+            // add a handler for checkboxes associated with nodes
+            this.on({
+                'checkchange' : function(node) {
+                    // If a parent node is unchecked, uncheck all
+                    // the children and vice versa
+                    var me = this;
+                    if(node.data.checked) {
+                        node.eachChild(function(child) {
+                            child.set('checked',true);
+                            me.fireEvent('checkchange',child,true);
+                        });
+                    } else {
+                        node.eachChild(function(child) {
+                            child.set('checked',false);
+                            me.fireEvent('checkchange',child,false);
+                        });
+                    }
+                    this.updateCheckboxes(node.parentNode);
+                },
+                scope: this
+            });
+        }
+    },
+
+    // private
+    processLayerStore: function() {
+        if (this.layerStore.getCount() > 0) {
+            this.onLayerAdded(
+                this.layerStore,
+                this.layerStore.data.items
+            );
+        }
+    },
+
+
+    // make sure that a parent checkbox is only checked if all of it's
+    // children are also checked
+    updateCheckboxes: function(node) {
+        if(node.isRoot()) return;
+        var allChecked = true;
+        for(var i=0; i<node.childNodes.length; i++) {
+            if(!node.childNodes[i].data.checked) allChecked = false;
+        }
+        node.set('checked',allChecked);
+        this.updateCheckboxes(node.parentNode);
+    },
+
+    onLayerAdded: function(store, records, index) {
+        // first, validate all 'group' options
+        Ext.each(records, function(record, index) {
+            var layer = record.getLayer();
+
+            if(layer.displayInLayerSwitcher === false) {
+                if(layer.group && layer.options && layer.options.group) {
+                    delete layer.group;
+                    delete layer.options.group;
+                }
+                return;
+            } else if(layer.options && layer.options.group === undefined) {
+                layer.options.group = (layer.isBaseLayer)
+                    ? this.baseLayersText : this.otherLayersText;
+            }
+        }, this);
+
+        // then, create the nodes according to the records
+        Ext.each(records, function(record, index) {
+            var layer = record.getLayer();
+
+            if (layer.displayInLayerSwitcher === false) {
+                return;
+            }
+
+            var groupString = layer.options.group || "";
+            var group = groupString.split('/');
+
+            // layers with group property set as empty string are added to
+            // the root node
+            if (groupString === "") {
+                this.getRootNode().appendChild({
+                    plugins: ['gx_layer'],
+                    layer: layer,
+                    text: layer.name
+                });
+            } else {
+                this.addGroupNodes(
+                    group, this.getRootNode(), groupString, record
+                );
+            }
+        }, this);
+    },
+
+    addGroupNodes: function(groups, parentNode, groupString, layerRecord){
+        var group = groups.shift(),
+            childNode = this.getNodeByText(parentNode, group),
+            layer = layerRecord.getLayer(),
+            checkableNode = false;
+
+        // if the childNode doesn't exist, we need to create and append it
+        if (!childNode) {
+            // if that's the last element of the groups array, we need a
+            // 'LayerContainer'
+            if (groups.length == 0) {
+                childNode = {
+                    expanded: (layer && layer.visibility),
+                    plugins: [{
+                        enableLegends: group != this.baseLayersText &&
+                                       group != this.otherLayersText,
+                        enableVectorLegends: this.enableVectorLegends,
+                        enableWmsLegends: this.enableWmsLegends,
+                        layerGroup: groupString,
+                        ptype: 'gx_layergroupcontainer'
+                    }],
+                    text: group
+                };
+            } else {
+                // else, create and append a simple node...
+                childNode = {
+                    allowDrag: false,
+                    expanded: (layer && layer.visibility),
+                    leaf: false,
+                    text: group
+                };
+            }
+
+            
+            if (childNode.plugins && childNode.plugins[0] && childNode.plugins[0].pype == "gx_layergroupcontainer") {
+                checkableNode = this.checkableLeafGroupNodes;
+            } else {
+                checkableNode = this.checkableContainerGroupNodes && this.checkableLeafGroupNodes;
+            }
+
+            // apply checkbox if option is set, set to checked by default - the
+            // listener for the checkchange has already been set in initComponent
+            if (checkableNode && group != this.baseLayersText &&
+                group != this.otherLayersText && (!layer || !layer.isBaseLayer)) {
+                childNode.checked = true;
+            }
+            parentNode.appendChild(childNode);
+
+            childNode = this.getNodeByText(parentNode, group);
+        }
+
+        // if node contains any child or grand-child with a visible layer,
+        // expand it, else if it contains any child or grand-child with a
+        // non-visible layer and it can have a checkbox, uncheck it
+        if (layer && layer.visibility) {
+            window.setTimeout(function() {
+                childNode.expand();
+            });
+        } else if(checkableNode && group != this.baseLayersText &&
+            group != this.otherLayersText && (!layer || !layer.isBaseLayer)) {
+            childNode.data.checked = false;
+        }
+
+        if (groups.length != 0){
+            this.addGroupNodes(groups, childNode, groupString, layerRecord);
+        }
+    },
+
+    getNodeByText: function(node, text){
+        for(var i=0; i<node.childNodes.length; i++)
+        {
+            if(node.childNodes[i].data['text'] == text)
+            {
+                return node.childNodes[i];
+            }
+        }
+        return false;
+    }
+});

--- a/src/GeoExt/tree/Util.js
+++ b/src/GeoExt/tree/Util.js
@@ -8,21 +8,24 @@ Ext.define('GeoExt.tree.Util', {
          * @param {boolean} checked the new checked state.
          */
         updateLayerVisibilityByNode: function(node, checked) {
-            if(checked != node.get('layer').getVisibility()) {
-                node._visibilityChanging = true;
-                var layer = node.get('layer');
-                if(checked && layer.isBaseLayer && layer.map) {
-                    layer.map.setBaseLayer(layer);
-                } else if(!checked && layer.isBaseLayer && layer.map &&
-                          layer.map.baseLayer && layer.id == layer.map.baseLayer.id) {
-                    // Must prevent the unchecking of radio buttons
-                    node.set('checked', layer.getVisibility());
-                } else {
-                    layer.setVisibility(checked);
+            var layer = node.get('layer');
+            if (layer) {
+                if(checked != node.get('layer').getVisibility()) {
+                    node._visibilityChanging = true;
+                    // var layer = node.get('layer');
+                    if(checked && layer.isBaseLayer && layer.map) {
+                        layer.map.setBaseLayer(layer);
+                    } else if(!checked && layer.isBaseLayer && layer.map &&
+                        layer.map.baseLayer && layer.id == layer.map.baseLayer.id) {
+                        // Must prevent the unchecking of radio buttons
+                        node.set('checked', layer.getVisibility());
+                    } else {
+                        layer.setVisibility(checked);
+                    }
+                    delete node._visibilityChanging;
                 }
-                delete node._visibilityChanging;
+                GeoExt.tree.Util.enforceOneLayerVisible(node);
             }
-            GeoExt.tree.Util.enforceOneLayerVisible(node);
         },
 
         /**


### PR DESCRIPTION
Hi devs,

I recovered these two classes that help create a layer tree, from an `group` attribute. I also add an example of usage, to `geoext2/examples/tree/`.

The only change in the existing code proposed in the PR is an additional protection (if clause) in `src/GeoExt/tree/Util.js`, `updateLayerVisibilityByNode` function, to make sure that we have a layer associated with the node before checking the layer's visibility. I think this test is necessary, since we might have nodes in the tree (not leafs) without a layer.

The two classes proposed in this PR are:
`GeoExt.tree.LayerTreeBuilder` that extends `GeoExt.tree.Panel`
`GeoExt.tree.LayerGroupContainer` that extends `GeoExt.tree.LayerContainer`

Comments are welcome.