### PR TITLE
Show load status of layers in tree panel

### DIFF
--- a/examples/tree/tree.js
+++ b/examples/tree/tree.js
@@ -31,8 +31,8 @@ Ext.application({
             region: "center",
             // we do not want all overlays, to try the OverlayLayerContainer
             map: {allOverlays: false},
-            center: [14, 37.5],
-            zoom: 7,
+            center: [14.15, 52.85],
+            zoom: 13,
             layers: [
                 new OpenLayers.Layer.WMS("Global Imagery",
                     "http://maps.opengeo.org/geowebcache/service/wms", {
@@ -81,7 +81,15 @@ Ext.application({
                         format: "image/png"
                     }, {
                         isBaseLayer: false,
-                        buffer: 0
+                        resolutions: [
+                            0.000171661376953125,
+                            0.0000858306884765625,
+                            0.00004291534423828125
+                        ],
+                        buffer: 0,
+                        metadata: {
+                            hideSpinnerInLayerTree: true
+                        }
                     }
                 ),
                 new OpenLayers.Layer.WMS("Bus Stops",
@@ -92,62 +100,20 @@ Ext.application({
                         transparent: true
                     },
                     {
-                        singleTile: true,
-                        visibility: false
-                    }
-                ),
-                // create a group layer (with several layers in the "layers" param)
-                // to show how the LayerParamLoader works
-                new OpenLayers.Layer.WMS("Tasmania (Group Layer)",
-                    "http://demo.opengeo.org/geoserver/wms", {
-                        layers: [
-                            "topp:tasmania_state_boundaries",
-                            "topp:tasmania_water_bodies",
-                            "topp:tasmania_cities",
-                            "topp:tasmania_roads"
-                        ],
-                        transparent: true,
-                        format: "image/gif"
-                    }, {
                         isBaseLayer: false,
-                        buffer: 0,
-                        // exclude this layer from layer container nodes
-                        displayInLayerSwitcher: false,
-                        visibility: false
+                        resolutions: [
+                            0.0000858306884765625,
+                            0.00004291534423828125
+                        ],
+                        singleTile: true,
+                        visibility: false,
+                        metadata: {
+                            hideSpinnerInLayerTree: true
+                        }
                     }
                 )
             ]
         });
-
-        // create our own layer node UI class, using the TreeNodeUIEventMixin
-        //var LayerNodeUI = Ext.extend(GeoExt.tree.LayerNodeUI, new GeoExt.tree.TreeNodeUIEventMixin());
-
-        /*var treeConfig = [
-            {nodeType: 'gx_layercontainer', layerStore: map.layers}
-        {
-            nodeType: "gx_baselayercontainer"
-        }, {
-            nodeType: "gx_overlaylayercontainer",
-            expanded: true,
-            // render the nodes inside this container with a radio button,
-            // and assign them the group "foo".
-            loader: {
-                baseAttrs: {
-                    radioGroup: "foo",
-                    uiProvider: "layernodeui"
-                }
-            }
-        }, {
-            nodeType: "gx_layer",
-            layer: "Tasmania (Group Layer)",
-            isLeaf: false,
-            // create subnodes for the layers in the LAYERS param. If we assign
-            // a loader to a LayerNode and do not provide a loader class, a
-            // LayerParamLoader will be assumed.
-            loader: {
-                param: "LAYERS"
-            }
-        }];*/
 
         var store = Ext.create('Ext.data.TreeStore', {
             model: 'GeoExt.data.LayerTreeModel',

--- a/src/GeoExt/data/LayerTreeModel.js
+++ b/src/GeoExt/data/LayerTreeModel.js
@@ -26,6 +26,9 @@
  *   if any.
  * * **disabled** Boolean: Used to reflect whether the associated layer is
  *   in range (visible in the current map scale).
+ *   **hideSpinnerInLayerTree** Boolean: Maps to the layers
+ *   metadata.hideSpinnerInLayerTree property to hide the load spinner in the
+ *   tree component.
  *
  * A typical configuration that makes use of some of these extended sttings
  * could look like this:
@@ -65,7 +68,16 @@ Ext.define('GeoExt.data.LayerTreeModel',{
         {name: 'checkedGroup', type: 'string'},
         {name: 'fixedText', type: 'bool'},
         {name: 'component'},
-        {name: 'disabled', type: 'bool', defaultValue: 'false'}
+        {name: 'disabled', type: 'bool', defaultValue: false},
+        {
+            name: 'hideSpinnerInLayerTree',
+            type: 'bool',
+            convert: function(v, record) {
+                var layer = record.data.layer,
+                    metadata = (layer ? layer.metadata : false);
+                return (metadata ? metadata.hideSpinnerInLayerTree : false);
+            }
+        }
     ],
     proxy: {
         type: "memory"

--- a/src/GeoExt/tree/LayerNode.js
+++ b/src/GeoExt/tree/LayerNode.js
@@ -85,10 +85,18 @@ Ext.define('GeoExt.tree.LayerNode', {
 
         target.on('afteredit', this.onAfterEdit, this);
 
-        layer.events.on({
+        var layerEvents = {
             'visibilitychanged': this.onLayerVisibilityChanged,
             scope: this
-        });
+        };
+
+        if (!target.get('hideSpinnerInLayerTree')) {
+            Ext.merge(layerEvents, {
+                'loadstart': this.onLayerLoadstart,
+                'loadend': this.onLayerLoadend,
+            });
+        }
+        layer.events.on(layerEvents);
 
         if (layer.map) {
             this.map = layer.map;
@@ -129,6 +137,14 @@ Ext.define('GeoExt.tree.LayerNode', {
         }
     },
 
+    onLayerLoadstart: function() {
+        this.target.set('loading', true);
+    },
+
+    onLayerLoadend: function() {
+        this.target.set('loading', false);
+    },
+
     /**
      * Handler for visibilitychanged events on the layer.
      *
@@ -157,6 +173,8 @@ Ext.define('GeoExt.tree.LayerNode', {
         target.un('afteredit', this.onAfterEdit, this);
 
         layer.events.un({
+            'loadstart': this.onLayerLoadstart,
+            'loadend': this.onLayerLoadend,
             'visibilitychanged': this.onLayerVisibilityChanged,
             scope: this
         });


### PR DESCRIPTION
This is a follow up to PR #357.

The 'loading' attribute is implicitly inherited by the NodeInterface that will be mixed into LayerTreeModel when added to a tree panel. Setting it to true will cause the node to show it's actual status in the tree panel temporarily replacing the layer icon with the Ext provided load spinner. It can be observed in the tree examples.
