### PR TITLE
Set version numbers to 2.1.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "GeoExt",
   "type": "code",
-  "version": "2.1.0-dev",
-  "compatVersion": "2.1.0-dev",
+  "version": "2.1.0-beta.2",
+  "compatVersion": "2.1.0-beta.2",
   "description": "A JavaScript Toolkit for Rich Web Mapping Applications based on OpenLayers and ExtJS.",
   "main": "index.js",
   "directories": {

--- a/src/GeoExt/Version.js
+++ b/src/GeoExt/Version.js
@@ -9,7 +9,7 @@
     var major = 2,
         minor = 1,
         patch = 0,
-        label = 'dev',
+        label = 'beta.2',
         environment = [],
         extVersions = Ext.versions.extjs,
         isExt5 = false,


### PR DESCRIPTION
For the next beta release (2.1.0-beta.2) the version number declarations
have to be adapted.