### PR TITLE
Fix JavaScript error when the map panel is loaded in a hidden ExtJS tab

### DIFF
--- a/src/GeoExt/tree/Util.js
+++ b/src/GeoExt/tree/Util.js
@@ -37,7 +37,9 @@ Ext.define('GeoExt.tree.Util', {
             // enforcing visibility.
             if(group && group !== "gx_baselayer") {
                 var layer = node.get('layer');
-                var checkedNodes = node.getOwnerTree().getChecked();
+                var ownerTree = node.getOwnerTree();
+                if (ownerTree === undefined) return;
+                var checkedNodes = ownerTree.getChecked();
                 var checkedCount = 0;
                 // enforce "not more than one visible"
                 Ext.each(checkedNodes, function(n){


### PR DESCRIPTION
When the map panel is loaded in an initially hidden ExtJS tab, the owner tree is not yet rendered, so call to "node.getOwnerTree()" returns undefined.  This caused an error message when trying to call
"node.getOwnerTree().getChecked()".