### PR TITLE
Fix JavaScript error when the map panel is loaded in a hidden  ExtJS tab

### DIFF
--- a/src/GeoExt/tree/LayerNode.js
+++ b/src/GeoExt/tree/LayerNode.js
@@ -158,7 +158,11 @@ Ext.define('GeoExt.tree.LayerNode', {
         // enforcing visibility.
         if(group && group !== "gx_baselayer") {
             var layer = this.target.get('layer');
-            var checkedNodes = this.target.getOwnerTree().getChecked();
+            var ownerTree = this.target.getOwnerTree();
+            if (ownerTree === undefined) {
+                return;
+            }
+            var checkedNodes = ownerTree.getChecked();
             var checkedCount = 0;
             // enforce "not more than one visible"
             Ext.each(checkedNodes, function(n){


### PR DESCRIPTION
When the map panel is loaded in an initially hidden ExtJS tab, the
owner tree is not yet rendered, so call to "node.getOwnerTree()"
returns undefined.  This caused an error message when trying to call
"node.getOwnerTree().getChecked()".

Backported from 5cb2864198b8901c6ca0af01f59c35f02ed438da

See also #367

Cheers for any review.