### PR TITLE
Add additional check whether the tree node has a 'layer' property

### DIFF
--- a/src/GeoExt/tree/Util.js
+++ b/src/GeoExt/tree/Util.js
@@ -8,7 +8,7 @@ Ext.define('GeoExt.tree.Util', {
          * @param {boolean} checked the new checked state.
          */
         updateLayerVisibilityByNode: function(node, checked) {
-            if(checked != node.get('layer').getVisibility()) {
+            if(node.get('layer') && checked != node.get('layer').getVisibility()) {
                 node._visibilityChanging = true;
                 var layer = node.get('layer');
                 if(checked && layer.isBaseLayer && layer.map) {

--- a/src/GeoExt/tree/Util.js
+++ b/src/GeoExt/tree/Util.js
@@ -8,9 +8,9 @@ Ext.define('GeoExt.tree.Util', {
          * @param {boolean} checked the new checked state.
          */
         updateLayerVisibilityByNode: function(node, checked) {
-            if(node.get('layer') && checked != node.get('layer').getVisibility()) {
+            var layer = node.get('layer');
+            if(layer && checked != layer.getVisibility()) {
                 node._visibilityChanging = true;
-                var layer = node.get('layer');
                 if(checked && layer.isBaseLayer && layer.map) {
                     layer.map.setBaseLayer(layer);
                 } else if(!checked && layer.isBaseLayer && layer.map &&
@@ -52,7 +52,7 @@ Ext.define('GeoExt.tree.Util', {
                     }
                 });
                 // enforce "at least one visible"
-                if(checkedCount === 0 && attributes.checked == false) {
+                if(checkedCount === 0 && attributes.checked === false) {
                     layer.setVisibility(true);
                 }
             }


### PR DESCRIPTION
Hi devs,

I would suggest to add an additional check in class ```GeoExt.tree.Util.js``` to ensure if a tree node really has a property 'layer' before its visibility is updated.

This mini check could be useful for applications, that use complex layer trees with nested folder structures (e.g. layer folder has checkboxes to check/uncheck all layers inside). In this case the folder itself has obviously no corresponding layer.

See also PR #355, especially df4ec85 - it handles the same issue, just solved in a bit other way ;)