### PR TITLE
Update package.json for compat with Sencha tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "GeoExt",
+  "namespace": "GeoExt",
   "type": "code",
-  "version": "2.1.1-dev",
-  "compatVersion": "2.1.1-dev",
+  "version": "2.1.1",
+  "compatVersion": "2.1.1",
   "description": "A JavaScript Toolkit for Rich Web Mapping Applications based on OpenLayers and ExtJS.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Removes the `-dev` suffix from version and adds attribute `namespace` which is created by the Sencha Cmd tool upgrading the package. As all components reside in that namespace anyway, this should be good to go.