### PR TITLE
Avoid too wide colums in TreePanel (ExtJS 5)

### DIFF
--- a/src/GeoExt/tree/Panel.js
+++ b/src/GeoExt/tree/Panel.js
@@ -41,7 +41,6 @@ Ext.define('GeoExt.tree.Panel', {
             me.columns = [{
                 xtype    : 'gx_treecolumn',
                 text     : 'Name',
-                width    : Ext.isIE6 ? null : 10000,
                 dataIndex: me.displayField         
             }];
         }


### PR DESCRIPTION
This avoids 10000px wide colums in the TreePanel when working with ExtJS 5.

This happened because the ``Ext.isIE6`` flag is gone in ExtJS 5, what always activated the IE6 workaround with setting the column width to 10000px. Since we do not support IE 6 I removed the ternary operator by setting the width to ``100%`` which works for ExtJS 4 and 5.