### PR TITLE
Prefix GeoExt components with "gx_"

### DIFF
--- a/src/GeoExt/data/reader/Feature.js
+++ b/src/GeoExt/data/reader/Feature.js
@@ -18,7 +18,10 @@
  */
 Ext.define('GeoExt.data.reader.Feature', {
     extend: 'Ext.data.reader.Json',
-    alias : 'reader.feature',
+    alias : [
+        'reader.gx_feature',
+        'reader.feature'
+    ],
     requires: [
         'GeoExt.Version'
     ],

--- a/src/GeoExt/form/action/Search.js
+++ b/src/GeoExt/form/action/Search.js
@@ -75,7 +75,10 @@
 Ext.define('GeoExt.form.action.Search', {
     extend: 'Ext.form.Action',
     alternateClassName: 'GeoExt.form.SearchAction',
-    alias: 'formaction.search',
+    alias: [
+        'formaction.gx_search',
+        'formaction.search'
+    ],
     requires: ['GeoExt.Form'],
 
     /**

--- a/src/GeoExt/selection/FeatureModel.js
+++ b/src/GeoExt/selection/FeatureModel.js
@@ -43,7 +43,10 @@
  */
 Ext.define('GeoExt.selection.FeatureModel', {
     extend: 'Ext.selection.RowModel',
-    alias: 'selection.featuremodel',
+    alias: [
+        'selection.gx_featuremodel',
+        'selection.featuremodel'
+    ],
     requires: [
         'GeoExt.Version'
     ],


### PR DESCRIPTION
Fixes #146. Old aliases haven't been removed for backwards compatibility.