### PR TITLE
Add fallback for ExtJS5 to return the layer.

### DIFF
--- a/src/GeoExt/data/LayerModel.js
+++ b/src/GeoExt/data/LayerModel.js
@@ -56,6 +56,6 @@ Ext.define('GeoExt.data.LayerModel',{
      * @return {OpenLayers.Layer}
      */
     getLayer: function() {
-        return this.raw;
+        return this.raw || this.data;
     }
 });


### PR DESCRIPTION
This is a small PR which adds a fallback to the `getLayer()` method in the `LayerModel` so it works even if `this.raw` is undefined. E.g. for ExtJS5.

This resolves #390
